### PR TITLE
Update receive_check.ino

### DIFF
--- a/example/receive_check/receive_check.ino
+++ b/example/receive_check/receive_check.ino
@@ -35,7 +35,7 @@ START_INIT:
 
 void loop()
 {
-    if(MCP_STAT_RXIF_MASK == CAN.checkReceive())            // check if data coming
+    if(CAN_MSGAVAIL == CAN.checkReceive())            // check if data coming
     {
         CAN.readMsgBuf(&len, buf);    // read data,  len: data length, buf: data buf
 


### PR DESCRIPTION
Checking CAN.checkReceive() agains MC_STAT_RXIF_MASK doesn't seem to make sense, it was confusing to me because the code seemed to be using equality with a mask. Since checkReceive() actually returns CAN_MSGAVAIL or CAN_NOMSG, Comparison with CAN_MSGAVAIL seemed more informative than MC_STAT_RXIF_MASK.
