### PR TITLE
Set SPICS pin to output in begin()

### DIFF
--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -576,6 +576,9 @@ INT8U MCP_CAN::begin(INT8U speedset)
 {
     INT8U res;
 
+    MCP2515_UNSELECT();                                                 /* disable chip select to begin with */
+    pinMode(SPICS, OUTPUT);                                             /* make chip select pin an output */
+
     SPI.begin();
     res = mcp2515_init(speedset);
     if (res == MCP2515_OK) return CAN_OK;


### PR DESCRIPTION
It took me a while to figure this out, but the SPICS pin is not necessarily initialized to output when the arduino starts. Explicitly making it an output in the begin() method saves the library user from having to set the pin as output in their code (which they may not know they need to do, since it is not in the example code).
