### PR TITLE
fixed corrupted can id bug

### DIFF
--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -473,7 +473,7 @@ void MCP_CAN::mcp2515_read_id( const INT8U mcp_addr,
                                                                         /* extended id                  */
         *id = (*id<<2) + (tbufdata[MCP_SIDL] & 0x03);
         *id <<= 16;
-        *id = *id +(tbufdata[MCP_EID8]<<8) + tbufdata[MCP_EID0];
+        *id = *id + (unsigned)(tbufdata[MCP_EID8]<<8) + tbufdata[MCP_EID0];
         *ext = 1;
     }
 }


### PR DESCRIPTION
There was an error in the bit arithmatic for the can id.

Basically, if the 15th bit of the id was set, then the upper 16bits were 1 less than they should be.
e.g. 0x0001(8-F)XXX -> 0x0000(8-F)XXX
e.g. 0x0000(8-F)XXX -> 0xFFFF(8-F)XXX

The offending operation is (tbufdata[MCP_EID8]<<8). This promotes an unsigned char to a signed int, which results in the corrupted ids. The fix is to cast it to an unsigned int. Note that int's are 16 bit on avr.
