### PR TITLE
Possibility to handle frames with request bit set

### DIFF
--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -650,12 +650,13 @@ INT8U MCP_CAN::init_Filt(INT8U num, INT8U ext, INT32U ulData)
 ** Function name:           setMsg
 ** Descriptions:            set can message, such as dlc, id, dta[] and so on
 *********************************************************************************************************/
-INT8U MCP_CAN::setMsg(INT32U id, INT8U ext, INT8U len, INT8U *pData)
+INT8U MCP_CAN::setMsg(INT32U id, INT8U ext, INT8U len, INT8U rtr, INT8U *pData)
 {
     int i = 0;
     m_nExtFlg = ext;
     m_nID     = id;
     m_nDlc    = len;
+    m_nRtr    = rtr;
     for(i = 0; i<MAX_CHAR_IN_MESSAGE; i++)
     {
         m_nDta[i] = *(pData+i);
@@ -719,9 +720,9 @@ INT8U MCP_CAN::sendMsg()
 ** Function name:           sendMsgBuf
 ** Descriptions:            send buf
 *********************************************************************************************************/
-INT8U MCP_CAN::sendMsgBuf(INT32U id, INT8U ext, INT8U len, INT8U *buf)
+INT8U MCP_CAN::sendMsgBuf(INT32U id, INT8U ext, INT8U rtr, INT8U len, INT8U *buf)
 {
-    setMsg(id, ext, len, buf);
+    setMsg(id, ext, len, rtr, buf);
     sendMsg();
 }
 
@@ -839,7 +840,16 @@ INT8U MCP_CAN::checkError(void)
 INT32U MCP_CAN::getCanId(void)
 {
     return m_nID;
-}
+} 
+
+/*********************************************************************************************************
+** Function name:           isRemoteRequest
+** Descriptions:            when receive something ,u can check if it was a request
+*********************************************************************************************************/
+INT8U MCP_CAN::isRemoteRequest(void)
+{
+    return m_nRtr;
+} 
 /*********************************************************************************************************
   END FILE
 *********************************************************************************************************/

--- a/mcp_can.h
+++ b/mcp_can.h
@@ -88,7 +88,7 @@ private:
 *  can operator function
 */    
 
-    INT8U setMsg(INT32U id, INT8U ext, INT8U len, INT8U *pData);    /* set message                  */  
+    INT8U setMsg(INT32U id, INT8U ext, INT8U len, INT8U rtr, INT8U *pData); /* set message                  */  
     INT8U clearMsg();                                               /* clear all message to zero    */
     INT8U readMsg();                                                /* read message                 */
     INT8U sendMsg();                                                /* send message                 */
@@ -98,12 +98,13 @@ public:
     INT8U begin(INT8U speedset);                              /* init can                     */
     INT8U init_Mask(INT8U num, INT8U ext, INT32U ulData);           /* init Masks                   */
     INT8U init_Filt(INT8U num, INT8U ext, INT32U ulData);           /* init filters                 */
-    INT8U sendMsgBuf(INT32U id, INT8U ext, INT8U len, INT8U *buf);  /* send buf                     */
+    INT8U sendMsgBuf(INT32U id, INT8U ext, INT8U rtr, INT8U len, INT8U *buf); /* send buf                     */
     INT8U readMsgBuf(INT8U *len, INT8U *buf);                       /* read buf                     */
     INT8U readMsgBufID(INT32U *ID, INT8U *len, INT8U *buf);         /* read buf with object ID      */
     INT8U checkReceive(void);                                       /* if something received        */
     INT8U checkError(void);                                         /* if something error           */
     INT32U getCanId(void);                                          /* get can id when receive      */
+    INT8U isRemoteRequest(void);                                    /* get RR flag when receive     */
 };
 
 #endif


### PR DESCRIPTION
Bugfix: When receiving a frame with remote request bit set
not clearing m_nRtr until next data frame without request bit is
received. This lead to sending out all frames in between with
request bit set aswell. Fixed by extending sendMsgBuf to
INT8U sendMsgBuf(INT32U id, INT8U ext, INT8U rtr, INT8U len, INT8U *buf)
and setMsg to
INT8U setMsg(INT32U id, INT8U ext, INT8U len, INT8U rtr, INT8U *pData)
giving the possibillity to specify if request bit is set or not when
sending a message.

Feature: New function INT8U MCP_CAN::isRemoteRequest(void) added
to make it possible to check if the remote request bit was set on
the last received message.
