### PR TITLE
Receive may freeze if CAN saturated

### DIFF
--- a/examples/receive_interrupt/receive_interrupt.ino
+++ b/examples/receive_interrupt/receive_interrupt.ino
@@ -41,18 +41,25 @@ void MCP2515_ISR()
 
 void loop()
 {
-    if(Flag_Recv)                   // check if get data
-    {
+  if(Flag_Recv) {                   // check if get data
     
-        Flag_Recv = 0;                // clear flag
-        CAN.readMsgBuf(&len, buf);    // read data,  len: data length, buf: data buf
-
-        for(int i = 0; i<len; i++)    // print the data
-        {
-            Serial.print(buf[i]);Serial.print("\t");
-        }
-        Serial.println();
-    }
+    Flag_Recv = 0;                // clear flag
+    
+    // iterate over all pending messages
+    // If either the bus is saturated or the MCU is busy,
+    // both RX buffers may be in use and reading a single
+    // message does not clear the IRQ conditon.
+    while (CAN_MSGAVAIL == CAN.checkReceive()) {
+      // read data,  len: data length, buf: data buf
+      CAN.readMsgBuf(&len, buf);
+      
+      // print the data
+      for(int i = 0; i<len; i++) {
+	Serial.print(buf[i]);Serial.print("\t");
+      }
+      Serial.println();
+    } 
+  }
 }
 
 /*********************************************************************************************************


### PR DESCRIPTION
If either the CANBUS is saturated or the MCU is busy for some time, both RX buffers of the MCP2515 may be in use. If the MCU does not catch up in processing the incoming messages, the second message received just adds another reason for the IRQ.
Thus reading a single message does not clear the IRQ conditon of the MCP2515 leading to a permanent lock up of the receiver program.

Signed-off-by: Ralf Edmund Stranzenbach ralf@reswi.de
