### PR TITLE
Added an offset to the txbuf_n pointer so that the actual ctrl reg value is read.

### DIFF
--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -769,7 +769,7 @@ INT8U MCP_CAN::sendMsg()
     do
     {
         uiTimeOut++;        
-        res1= mcp2515_readRegister(txbuf_n);  			                /* read send buff ctrl reg 	*/
+        res1= mcp2515_readRegister(txbuf_n-1 /* the ctrl reg is located at txbuf_n-1 */);  /* read send buff ctrl reg 	*/
         res1 = res1 & 0x08;                               		
     }while(res1 && (uiTimeOut < TIMEOUTVALUE));   
     if(uiTimeOut == TIMEOUTVALUE)                                       /* send msg timeout             */	


### PR DESCRIPTION
The original code reads address 0x31, 0x41, or 0x51 "TXBnSIDH – TRANSMIT
BUFFER n STANDARD IDENTIFIER HIGH".  Because that location points to a
constant value, some of the msg ids cause the program to loop 50 times
and then report a timeout error.  After changing the address to point to
0x30, 0x40, or 0x50 "TXBnCTRL – TRANSMIT BUFFER n CONTROL REGISTER", all
of the messages send out properally with no timeout errors.