### PR TITLE
examples/receive_check/receive_check.ino ID format fix

### DIFF
--- a/examples/receive_check/receive_check.ino
+++ b/examples/receive_check/receive_check.ino
@@ -42,11 +42,11 @@ void loop()
     {
         CAN.readMsgBuf(&len, buf);    // read data,  len: data length, buf: data buf
 
-        unsigned char canId = CAN.getCanId();
+        unsigned long canId = CAN.getCanId();
         
         Serial.println("-----------------------------");
-        Serial.println("get data from ID: ");
-        Serial.println(canId);
+        Serial.print("get data from ID: ");
+        Serial.println(canId, HEX);
 
         for(int i = 0; i<len; i++)    // print the data
         {


### PR DESCRIPTION
The ID format wasn't correct. ID has 4 bytes not 1. It was intended to be printed next to the text and HEX format is better to read - that's how CAN professionals work with it.