### PR TITLE
Cleanup on setMsg

### DIFF
--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -716,7 +716,7 @@ INT8U MCP_CAN::setMsg(INT32U id, INT8U ext, INT8U len, INT8U rtr, INT8U *pData)
 *********************************************************************************************************/
 INT8U MCP_CAN::setMsg(INT32U id, INT8U ext, INT8U len, INT8U *pData)
 {
-    setMsg( id, ext, len, 0, pData );
+    return setMsg( id, ext, len, 0, pData );
 }
 
 /*********************************************************************************************************

--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -698,12 +698,11 @@ INT8U MCP_CAN::init_Filt(INT8U num, INT8U ext, INT32U ulData)
 *********************************************************************************************************/
 INT8U MCP_CAN::setMsg(INT32U id, INT8U ext, INT8U len, INT8U rtr, INT8U *pData)
 {
-    int i = 0;
     m_nExtFlg = ext;
     m_nID     = id;
-    m_nDlc    = len;
+    m_nDlc    = min( len, MAX_CHAR_IN_MESSAGE );
     m_nRtr    = rtr;
-    for(i = 0; i<MAX_CHAR_IN_MESSAGE; i++)
+    for(int i = 0; i<m_nDlc; i++)
     {
         m_nDta[i] = *(pData+i);
     }
@@ -717,15 +716,7 @@ INT8U MCP_CAN::setMsg(INT32U id, INT8U ext, INT8U len, INT8U rtr, INT8U *pData)
 *********************************************************************************************************/
 INT8U MCP_CAN::setMsg(INT32U id, INT8U ext, INT8U len, INT8U *pData)
 {
-    int i = 0;
-    m_nExtFlg = ext;
-    m_nID     = id;
-    m_nDlc    = len;
-    for(i = 0; i<MAX_CHAR_IN_MESSAGE; i++)
-    {
-        m_nDta[i] = *(pData+i);
-    }
-    return MCP2515_OK;
+    setMsg( id, ext, len, 0, pData );
 }
 
 /*********************************************************************************************************


### PR DESCRIPTION
Force setMsg to clear RTR so it does not use the previous value. Have setMsg copy only as many bytes as necessary. Limit max DLC to 8.