### PR TITLE
Improved speed, 8MHz clock support, support for NMEA2000 library

### DIFF
--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -21,6 +21,7 @@
   Btetz
   Hurvajs
   xboxpro1
+  ttlappalainen
 
   The MIT License (MIT)
 
@@ -46,10 +47,107 @@
 */
 #include "mcp_can.h"
 
-#define spi_readwrite   SPI.transfer
-#define spi_read()      spi_readwrite(0x00)
-#define SPI_BEGIN()     SPI.beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0))
-#define SPI_END()       SPI.endTransaction()
+#define spi_readwrite      pSPI->transfer
+#define spi_read()         spi_readwrite(0x00)
+#define spi_write(spi_val) spi_readwrite(spi_val)
+#define SPI_BEGIN()        pSPI->beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0))
+#define SPI_END()          pSPI->endTransaction()
+
+/*********************************************************************************************************
+** Function name:           txCtrlReg
+** Descriptions:            return tx ctrl reg according to tx buffer index.
+**                          According to my tests this is faster and saves memory compared using vector
+*********************************************************************************************************/
+byte txCtrlReg(byte i) {
+  switch (i) {
+    case 0: return MCP_TXB0CTRL;
+    case 1: return MCP_TXB1CTRL;
+    case 2: return MCP_TXB2CTRL;
+  }
+  return MCP_TXB2CTRL;
+}
+
+/*********************************************************************************************************
+** Function name:           statusToBuffer
+** Descriptions:            converts CANINTF status to tx buffer index
+*********************************************************************************************************/
+byte statusToTxBuffer(byte status)
+{
+  switch ( status ) {
+    case MCP_TX0IF : return 0;
+    case MCP_TX1IF : return 1;
+    case MCP_TX2IF : return 2;
+  }
+  
+  return 0xff;
+}
+
+/*********************************************************************************************************
+** Function name:           statusToBuffer
+** Descriptions:            converts CANINTF status to tx buffer sidh
+*********************************************************************************************************/
+byte statusToTxSidh(byte status)
+{
+  switch ( status ) {
+    case MCP_TX0IF : return MCP_TXB0SIDH;
+    case MCP_TX1IF : return MCP_TXB1SIDH;
+    case MCP_TX2IF : return MCP_TXB2SIDH;
+  }
+  
+  return 0;
+}
+
+/*********************************************************************************************************
+** Function name:           txSidhToTxLoad
+** Descriptions:            return tx load command according to tx buffer sidh register
+*********************************************************************************************************/
+byte txSidhToRTS(byte sidh) {
+  switch (sidh) {
+    case MCP_TXB0SIDH: return MCP_RTS_TX0;
+    case MCP_TXB1SIDH: return MCP_RTS_TX1;
+    case MCP_TXB2SIDH: return MCP_RTS_TX2;
+  }
+  return 0;
+}
+
+/*********************************************************************************************************
+** Function name:           txSidhToTxLoad
+** Descriptions:            return tx load command according to tx buffer sidh register
+*********************************************************************************************************/
+byte txSidhToTxLoad(byte sidh) {
+  switch (sidh) {
+    case MCP_TXB0SIDH: return MCP_LOAD_TX0;
+    case MCP_TXB1SIDH: return MCP_LOAD_TX1;
+    case MCP_TXB2SIDH: return MCP_LOAD_TX2;
+  }
+  return 0;
+}
+
+/*********************************************************************************************************
+** Function name:           txIfFlag
+** Descriptions:            return tx interrupt flag
+*********************************************************************************************************/
+byte txIfFlag(byte i) {
+  switch (i) {
+    case 0: return MCP_TX0IF;
+    case 1: return MCP_TX1IF;
+    case 2: return MCP_TX2IF;
+  }
+  return 0;
+}
+
+/*********************************************************************************************************
+** Function name:           txStatusPendingFlag
+** Descriptions:            return buffer tx pending flag on status
+*********************************************************************************************************/
+byte txStatusPendingFlag(byte i) {
+  switch (i) {
+    case 0: return MCP_STAT_TX0_PENDING;
+    case 1: return MCP_STAT_TX1_PENDING;
+    case 2: return MCP_STAT_TX2_PENDING;
+  }
+  return 0xff;
+}
 
 /*********************************************************************************************************
 ** Function name:           mcp2515_reset
@@ -106,9 +204,9 @@ void MCP_CAN::mcp2515_readRegisterS(const byte address, byte values[], const byt
     spi_readwrite(MCP_READ);
     spi_readwrite(address);
     // mcp2515 has auto-increment of address-pointer
-    for(i=0; i<n && i<CAN_MAX_CHAR_IN_MESSAGE; i++)
+    for (i=0; i<n && i<CAN_MAX_CHAR_IN_MESSAGE; i++)
     {
-        values[i] = spi_read();
+      values[i] = spi_read();
     }
     MCP2515_UNSELECT();
 #ifdef SPI_HAS_TRANSACTION
@@ -149,9 +247,9 @@ void MCP_CAN::mcp2515_setRegisterS(const byte address, const byte values[], cons
     spi_readwrite(MCP_WRITE);
     spi_readwrite(address);
 
-    for(i=0; i<n; i++)
+    for (i=0; i<n; i++)
     {
-        spi_readwrite(values[i]);
+      spi_readwrite(values[i]);
     }
     MCP2515_UNSELECT();
 #ifdef SPI_HAS_TRANSACTION
@@ -213,9 +311,9 @@ byte MCP_CAN::mcp2515_setCANCTRL_Mode(const byte newmode)
     i = mcp2515_readRegister(MCP_CANCTRL);
     i &= MODE_MASK;
 
-    if(i == newmode)
+    if ( i == newmode )
     {
-        return MCP2515_OK;
+      return MCP2515_OK;
     }
 
     return MCP2515_FAIL;
@@ -223,136 +321,232 @@ byte MCP_CAN::mcp2515_setCANCTRL_Mode(const byte newmode)
 
 /*********************************************************************************************************
 ** Function name:           mcp2515_configRate
-** Descriptions:            set boadrate
+** Descriptions:            set baudrate
 *********************************************************************************************************/
-byte MCP_CAN::mcp2515_configRate(const byte canSpeed)
+byte MCP_CAN::mcp2515_configRate(const byte canSpeed, const byte clock)
 {
-    byte set, cfg1, cfg2, cfg3;
-    set = 1;
-    switch (canSpeed)
-    {
+  byte set, cfg1, cfg2, cfg3;
+  set = 1;
+  switch (clock)
+  {
+    case (MCP_16MHz) :
+      switch (canSpeed)
+      {
         case (CAN_5KBPS):
-        cfg1 = MCP_16MHz_5kBPS_CFG1;
-        cfg2 = MCP_16MHz_5kBPS_CFG2;
-        cfg3 = MCP_16MHz_5kBPS_CFG3;
-        break;
+          cfg1 = MCP_16MHz_5kBPS_CFG1;
+          cfg2 = MCP_16MHz_5kBPS_CFG2;
+          cfg3 = MCP_16MHz_5kBPS_CFG3;
+          break;
 
         case (CAN_10KBPS):
-        cfg1 = MCP_16MHz_10kBPS_CFG1;
-        cfg2 = MCP_16MHz_10kBPS_CFG2;
-        cfg3 = MCP_16MHz_10kBPS_CFG3;
-        break;
+          cfg1 = MCP_16MHz_10kBPS_CFG1;
+          cfg2 = MCP_16MHz_10kBPS_CFG2;
+          cfg3 = MCP_16MHz_10kBPS_CFG3;
+          break;
 
         case (CAN_20KBPS):
-        cfg1 = MCP_16MHz_20kBPS_CFG1;
-        cfg2 = MCP_16MHz_20kBPS_CFG2;
-        cfg3 = MCP_16MHz_20kBPS_CFG3;
-        break;
+          cfg1 = MCP_16MHz_20kBPS_CFG1;
+          cfg2 = MCP_16MHz_20kBPS_CFG2;
+          cfg3 = MCP_16MHz_20kBPS_CFG3;
+          break;
 
         case (CAN_25KBPS):
-        cfg1 = MCP_16MHz_25kBPS_CFG1;
-        cfg2 = MCP_16MHz_25kBPS_CFG2;
-        cfg3 = MCP_16MHz_25kBPS_CFG3;
-        break;
+          cfg1 = MCP_16MHz_25kBPS_CFG1;
+          cfg2 = MCP_16MHz_25kBPS_CFG2;
+          cfg3 = MCP_16MHz_25kBPS_CFG3;
+          break;
 
         case (CAN_31K25BPS):
-        cfg1 = MCP_16MHz_31k25BPS_CFG1;
-        cfg2 = MCP_16MHz_31k25BPS_CFG2;
-        cfg3 = MCP_16MHz_31k25BPS_CFG3;
-        break;
+          cfg1 = MCP_16MHz_31k25BPS_CFG1;
+          cfg2 = MCP_16MHz_31k25BPS_CFG2;
+          cfg3 = MCP_16MHz_31k25BPS_CFG3;
+          break;
 
         case (CAN_33KBPS):
-        cfg1 = MCP_16MHz_33kBPS_CFG1;
-        cfg2 = MCP_16MHz_33kBPS_CFG2;
-        cfg3 = MCP_16MHz_33kBPS_CFG3;
-        break;
+          cfg1 = MCP_16MHz_33kBPS_CFG1;
+          cfg2 = MCP_16MHz_33kBPS_CFG2;
+          cfg3 = MCP_16MHz_33kBPS_CFG3;
+          break;
 
         case (CAN_40KBPS):
-        cfg1 = MCP_16MHz_40kBPS_CFG1;
-        cfg2 = MCP_16MHz_40kBPS_CFG2;
-        cfg3 = MCP_16MHz_40kBPS_CFG3;
-        break;
+          cfg1 = MCP_16MHz_40kBPS_CFG1;
+          cfg2 = MCP_16MHz_40kBPS_CFG2;
+          cfg3 = MCP_16MHz_40kBPS_CFG3;
+          break;
 
         case (CAN_50KBPS):
-        cfg1 = MCP_16MHz_50kBPS_CFG1;
-        cfg2 = MCP_16MHz_50kBPS_CFG2;
-        cfg3 = MCP_16MHz_50kBPS_CFG3;
-        break;
+          cfg1 = MCP_16MHz_50kBPS_CFG1;
+          cfg2 = MCP_16MHz_50kBPS_CFG2;
+          cfg3 = MCP_16MHz_50kBPS_CFG3;
+          break;
 
         case (CAN_80KBPS):
-        cfg1 = MCP_16MHz_80kBPS_CFG1;
-        cfg2 = MCP_16MHz_80kBPS_CFG2;
-        cfg3 = MCP_16MHz_80kBPS_CFG3;
-        break;
+          cfg1 = MCP_16MHz_80kBPS_CFG1;
+          cfg2 = MCP_16MHz_80kBPS_CFG2;
+          cfg3 = MCP_16MHz_80kBPS_CFG3;
+          break;
 
         case (CAN_83K3BPS):
-        cfg1 = MCP_16MHz_83k3BPS_CFG1;
-        cfg2 = MCP_16MHz_83k3BPS_CFG2;
-        cfg3 = MCP_16MHz_83k3BPS_CFG3;
-        break;
+          cfg1 = MCP_16MHz_83k3BPS_CFG1;
+          cfg2 = MCP_16MHz_83k3BPS_CFG2;
+          cfg3 = MCP_16MHz_83k3BPS_CFG3;
+          break;
 
         case (CAN_95KBPS):
-        cfg1 = MCP_16MHz_95kBPS_CFG1;
-        cfg2 = MCP_16MHz_95kBPS_CFG2;
-        cfg3 = MCP_16MHz_95kBPS_CFG3;
-        break;
+          cfg1 = MCP_16MHz_95kBPS_CFG1;
+          cfg2 = MCP_16MHz_95kBPS_CFG2;
+          cfg3 = MCP_16MHz_95kBPS_CFG3;
+          break;
 
         case (CAN_100KBPS):
-        cfg1 = MCP_16MHz_100kBPS_CFG1;
-        cfg2 = MCP_16MHz_100kBPS_CFG2;
-        cfg3 = MCP_16MHz_100kBPS_CFG3;
-        break;
+          cfg1 = MCP_16MHz_100kBPS_CFG1;
+          cfg2 = MCP_16MHz_100kBPS_CFG2;
+          cfg3 = MCP_16MHz_100kBPS_CFG3;
+          break;
 
         case (CAN_125KBPS):
-        cfg1 = MCP_16MHz_125kBPS_CFG1;
-        cfg2 = MCP_16MHz_125kBPS_CFG2;
-        cfg3 = MCP_16MHz_125kBPS_CFG3;
-        break;
+          cfg1 = MCP_16MHz_125kBPS_CFG1;
+          cfg2 = MCP_16MHz_125kBPS_CFG2;
+          cfg3 = MCP_16MHz_125kBPS_CFG3;
+          break;
 
         case (CAN_200KBPS):
-        cfg1 = MCP_16MHz_200kBPS_CFG1;
-        cfg2 = MCP_16MHz_200kBPS_CFG2;
-        cfg3 = MCP_16MHz_200kBPS_CFG3;
-        break;
+          cfg1 = MCP_16MHz_200kBPS_CFG1;
+          cfg2 = MCP_16MHz_200kBPS_CFG2;
+          cfg3 = MCP_16MHz_200kBPS_CFG3;
+          break;
 
         case (CAN_250KBPS):
-        cfg1 = MCP_16MHz_250kBPS_CFG1;
-        cfg2 = MCP_16MHz_250kBPS_CFG2;
-        cfg3 = MCP_16MHz_250kBPS_CFG3;
-        break;
+          cfg1 = MCP_16MHz_250kBPS_CFG1;
+          cfg2 = MCP_16MHz_250kBPS_CFG2;
+          cfg3 = MCP_16MHz_250kBPS_CFG3;
+          break;
 
         case (CAN_500KBPS):
-        cfg1 = MCP_16MHz_500kBPS_CFG1;
-        cfg2 = MCP_16MHz_500kBPS_CFG2;
-        cfg3 = MCP_16MHz_500kBPS_CFG3;
-        break;
+          cfg1 = MCP_16MHz_500kBPS_CFG1;
+          cfg2 = MCP_16MHz_500kBPS_CFG2;
+          cfg3 = MCP_16MHz_500kBPS_CFG3;
+          break;
 
         case (CAN_666KBPS):
-        cfg1 = MCP_16MHz_666kBPS_CFG1;
-        cfg2 = MCP_16MHz_666kBPS_CFG2;
-        cfg3 = MCP_16MHz_666kBPS_CFG3;
-        break;
+          cfg1 = MCP_16MHz_666kBPS_CFG1;
+          cfg2 = MCP_16MHz_666kBPS_CFG2;
+          cfg3 = MCP_16MHz_666kBPS_CFG3;
+          break;
 
         case (CAN_1000KBPS):
-        cfg1 = MCP_16MHz_1000kBPS_CFG1;
-        cfg2 = MCP_16MHz_1000kBPS_CFG2;
-        cfg3 = MCP_16MHz_1000kBPS_CFG3;
-        break;
+          cfg1 = MCP_16MHz_1000kBPS_CFG1;
+          cfg2 = MCP_16MHz_1000kBPS_CFG2;
+          cfg3 = MCP_16MHz_1000kBPS_CFG3;
+          break;
 
         default:
-        set = 0;
-        break;
-    }
+          set = 0;
+          break;
+      }
+      break;
 
-    if(set) {
-        mcp2515_setRegister(MCP_CNF1, cfg1);
-        mcp2515_setRegister(MCP_CNF2, cfg2);
-        mcp2515_setRegister(MCP_CNF3, cfg3);
-        return MCP2515_OK;
-    }
-    else {
-        return MCP2515_FAIL;
-    }
+    case (MCP_8MHz) :
+      switch (canSpeed)
+      {
+        case (CAN_5KBPS) :
+          cfg1 = MCP_8MHz_5kBPS_CFG1;
+          cfg2 = MCP_8MHz_5kBPS_CFG2;
+          cfg3 = MCP_8MHz_5kBPS_CFG3;
+          break;
+
+        case (CAN_10KBPS) :
+          cfg1 = MCP_8MHz_10kBPS_CFG1;
+          cfg2 = MCP_8MHz_10kBPS_CFG2;
+          cfg3 = MCP_8MHz_10kBPS_CFG3;
+          break;
+
+        case (CAN_20KBPS) :
+          cfg1 = MCP_8MHz_20kBPS_CFG1;
+          cfg2 = MCP_8MHz_20kBPS_CFG2;
+          cfg3 = MCP_8MHz_20kBPS_CFG3;
+          break;
+
+        case (CAN_31K25BPS) :
+          cfg1 = MCP_8MHz_31k25BPS_CFG1;
+          cfg2 = MCP_8MHz_31k25BPS_CFG2;
+          cfg3 = MCP_8MHz_31k25BPS_CFG3;
+          break;
+
+        case (CAN_40KBPS) :
+          cfg1 = MCP_8MHz_40kBPS_CFG1;
+          cfg2 = MCP_8MHz_40kBPS_CFG2;
+          cfg3 = MCP_8MHz_40kBPS_CFG3;
+          break;
+
+        case (CAN_50KBPS) :
+          cfg1 = MCP_8MHz_50kBPS_CFG1;
+          cfg2 = MCP_8MHz_50kBPS_CFG2;
+          cfg3 = MCP_8MHz_50kBPS_CFG3;
+          break;
+
+        case (CAN_80KBPS) :
+          cfg1 = MCP_8MHz_80kBPS_CFG1;
+          cfg2 = MCP_8MHz_80kBPS_CFG2;
+          cfg3 = MCP_8MHz_80kBPS_CFG3;
+          break;
+
+        case (CAN_100KBPS) :
+          cfg1 = MCP_8MHz_100kBPS_CFG1;
+          cfg2 = MCP_8MHz_100kBPS_CFG2;
+          cfg3 = MCP_8MHz_100kBPS_CFG3;
+          break;
+
+        case (CAN_125KBPS) :
+          cfg1 = MCP_8MHz_125kBPS_CFG1;
+          cfg2 = MCP_8MHz_125kBPS_CFG2;
+          cfg3 = MCP_8MHz_125kBPS_CFG3;
+          break;
+
+        case (CAN_200KBPS) :
+          cfg1 = MCP_8MHz_200kBPS_CFG1;
+          cfg2 = MCP_8MHz_200kBPS_CFG2;
+          cfg3 = MCP_8MHz_200kBPS_CFG3;
+          break;
+
+        case (CAN_250KBPS) :
+          cfg1 = MCP_8MHz_250kBPS_CFG1;
+          cfg2 = MCP_8MHz_250kBPS_CFG2;
+          cfg3 = MCP_8MHz_250kBPS_CFG3;
+          break;
+
+        case (CAN_500KBPS) :
+          cfg1 = MCP_8MHz_500kBPS_CFG1;
+          cfg2 = MCP_8MHz_500kBPS_CFG2;
+          cfg3 = MCP_8MHz_500kBPS_CFG3;
+          break;
+
+        case (CAN_1000KBPS) :
+          cfg1 = MCP_8MHz_1000kBPS_CFG1;
+          cfg2 = MCP_8MHz_1000kBPS_CFG2;
+          cfg3 = MCP_8MHz_1000kBPS_CFG3;
+          break;
+
+        default:
+          set = 0;
+          break;
+      }
+      break;
+
+    default:
+      set = 0;
+      break;
+  }
+
+  if (set) {
+    mcp2515_setRegister(MCP_CNF1, cfg1);
+    mcp2515_setRegister(MCP_CNF2, cfg2);
+    mcp2515_setRegister(MCP_CNF3, cfg3);
+    return MCP2515_OK;
+  }
+  else {
+    return MCP2515_FAIL;
+  }
 }
 
 /*********************************************************************************************************
@@ -366,14 +560,14 @@ void MCP_CAN::mcp2515_initCANBuffers(void)
     a1 = MCP_TXB0CTRL;
     a2 = MCP_TXB1CTRL;
     a3 = MCP_TXB2CTRL;
-    for(i = 0; i < 14; i++)                         // in-buffer loop
+    for (i = 0; i < 14; i++)                         // in-buffer loop
     {
-        mcp2515_setRegister(a1, 0);
-        mcp2515_setRegister(a2, 0);
-        mcp2515_setRegister(a3, 0);
-        a1++;
-        a2++;
-        a3++;
+      mcp2515_setRegister(a1, 0);
+      mcp2515_setRegister(a2, 0);
+      mcp2515_setRegister(a3, 0);
+      a1++;
+      a2++;
+      a3++;
     }
     mcp2515_setRegister(MCP_RXB0CTRL, 0);
     mcp2515_setRegister(MCP_RXB1CTRL, 0);
@@ -383,7 +577,7 @@ void MCP_CAN::mcp2515_initCANBuffers(void)
 ** Function name:           mcp2515_init
 ** Descriptions:            init the device
 *********************************************************************************************************/
-byte MCP_CAN::mcp2515_init(const byte canSpeed)
+byte MCP_CAN::mcp2515_init(const byte canSpeed, const byte clock)
 {
 
     byte res;
@@ -391,14 +585,14 @@ byte MCP_CAN::mcp2515_init(const byte canSpeed)
     mcp2515_reset();
 
     res = mcp2515_setCANCTRL_Mode(MODE_CONFIG);
-    if(res > 0)
+    if (res > 0)
     {
 #if DEBUG_EN
-        Serial.print("Enter setting mode fall\r\n");
+      Serial.print("Enter setting mode fail\r\n");
 #else
-        delay(10);
+      delay(10);
 #endif
-        return res;
+      return res;
     }
 #if DEBUG_EN
     Serial.print("Enter setting mode success \r\n");
@@ -407,14 +601,14 @@ byte MCP_CAN::mcp2515_init(const byte canSpeed)
 #endif
 
     // set boadrate
-    if(mcp2515_configRate(canSpeed))
+    if (mcp2515_configRate(canSpeed, clock))
     {
 #if DEBUG_EN
-        Serial.print("set rate fall!!\r\n");
+      Serial.print("set rate fall!!\r\n");
 #else
-        delay(10);
+      delay(10);
 #endif
-        return res;
+      return res;
     }
 #if DEBUG_EN
     Serial.print("set rate success!!\r\n");
@@ -422,46 +616,46 @@ byte MCP_CAN::mcp2515_init(const byte canSpeed)
     delay(10);
 #endif
 
-    if(res == MCP2515_OK) {
+    if ( res == MCP2515_OK ) {
 
-        // init canbuffers
-        mcp2515_initCANBuffers();
+      // init canbuffers
+      mcp2515_initCANBuffers();
 
-        // interrupt mode
-        mcp2515_setRegister(MCP_CANINTE, MCP_RX0IF | MCP_RX1IF);
+      // interrupt mode
+      mcp2515_setRegister(MCP_CANINTE, MCP_RX0IF | MCP_RX1IF);
 
 #if (DEBUG_RXANY==1)
-        // enable both receive-buffers to receive any message and enable rollover
-        mcp2515_modifyRegister(MCP_RXB0CTRL,
-        MCP_RXB_RX_MASK | MCP_RXB_BUKT_MASK,
-        MCP_RXB_RX_ANY | MCP_RXB_BUKT_MASK);
-        mcp2515_modifyRegister(MCP_RXB1CTRL, MCP_RXB_RX_MASK,
-        MCP_RXB_RX_ANY);
+      // enable both receive-buffers to receive any message and enable rollover
+      mcp2515_modifyRegister(MCP_RXB0CTRL,
+                             MCP_RXB_RX_MASK | MCP_RXB_BUKT_MASK,
+                             MCP_RXB_RX_ANY | MCP_RXB_BUKT_MASK);
+      mcp2515_modifyRegister(MCP_RXB1CTRL, MCP_RXB_RX_MASK,
+                             MCP_RXB_RX_ANY);
 #else
-        // enable both receive-buffers to receive messages with std. and ext. identifiers and enable rollover
-        mcp2515_modifyRegister(MCP_RXB0CTRL,
-        MCP_RXB_RX_MASK | MCP_RXB_BUKT_MASK,
-        MCP_RXB_RX_STDEXT | MCP_RXB_BUKT_MASK);
-        mcp2515_modifyRegister(MCP_RXB1CTRL, MCP_RXB_RX_MASK,
-        MCP_RXB_RX_STDEXT);
+      // enable both receive-buffers to receive messages with std. and ext. identifiers and enable rollover
+      mcp2515_modifyRegister(MCP_RXB0CTRL,
+                             MCP_RXB_RX_MASK | MCP_RXB_BUKT_MASK,
+                             MCP_RXB_RX_STDEXT | MCP_RXB_BUKT_MASK);
+      mcp2515_modifyRegister(MCP_RXB1CTRL, MCP_RXB_RX_MASK,
+                             MCP_RXB_RX_STDEXT);
 #endif
-        // enter normal mode
-        res = mcp2515_setCANCTRL_Mode(MODE_NORMAL);
-        if(res)
-        {
+      // enter normal mode
+      res = mcp2515_setCANCTRL_Mode(MODE_NORMAL);
+      if (res)
+      {
 #if DEBUG_EN
-            Serial.print("Enter Normal Mode Fall!!\r\n");
-#else
-            delay(10);
-#endif
-            return res;
-        }
-
-
-#if DEBUG_EN
-        Serial.print("Enter Normal Mode Success!!\r\n");
+        Serial.print("Enter Normal Mode Fail!!\r\n");
 #else
         delay(10);
+#endif
+        return res;
+      }
+
+
+#if DEBUG_EN
+      Serial.print("Enter Normal Mode Success!!\r\n");
+#else
+      delay(10);
 #endif
 
     }
@@ -470,33 +664,43 @@ byte MCP_CAN::mcp2515_init(const byte canSpeed)
 }
 
 /*********************************************************************************************************
+** Function name:           mcp2515_id_to_buf
+** Descriptions:            configure tbufdata[4] from id and ext
+*********************************************************************************************************/
+void mcp2515_id_to_buf(const byte ext, const unsigned long id, byte *tbufdata)
+{
+  uint16_t canid;
+
+  canid = (uint16_t)(id & 0x0FFFF);
+
+  if ( ext == 1)
+  {
+    tbufdata[MCP_EID0] = (byte) (canid & 0xFF);
+    tbufdata[MCP_EID8] = (byte) (canid >> 8);
+    canid = (uint16_t)(id >> 16);
+    tbufdata[MCP_SIDL] = (byte) (canid & 0x03);
+    tbufdata[MCP_SIDL] += (byte) ((canid & 0x1C) << 3);
+    tbufdata[MCP_SIDL] |= MCP_TXB_EXIDE_M;
+    tbufdata[MCP_SIDH] = (byte) (canid >> 5 );
+  }
+  else
+  {
+    tbufdata[MCP_SIDH] = (byte) (canid >> 3 );
+    tbufdata[MCP_SIDL] = (byte) ((canid & 0x07 ) << 5);
+    tbufdata[MCP_EID0] = 0;
+    tbufdata[MCP_EID8] = 0;
+  }
+}
+
+/*********************************************************************************************************
 ** Function name:           mcp2515_write_id
 ** Descriptions:            write can id
 *********************************************************************************************************/
 void MCP_CAN::mcp2515_write_id(const byte mcp_addr, const byte ext, const unsigned long id)
 {
-    uint16_t canid;
     byte tbufdata[4];
 
-    canid = (uint16_t)(id & 0x0FFFF);
-
-    if(ext == 1)
-    {
-        tbufdata[MCP_EID0] = (byte) (canid & 0xFF);
-        tbufdata[MCP_EID8] = (byte) (canid >> 8);
-        canid = (uint16_t)(id >> 16);
-        tbufdata[MCP_SIDL] = (byte) (canid & 0x03);
-        tbufdata[MCP_SIDL] += (byte) ((canid & 0x1C) << 3);
-        tbufdata[MCP_SIDL] |= MCP_TXB_EXIDE_M;
-        tbufdata[MCP_SIDH] = (byte) (canid >> 5);
-    }
-    else
-    {
-        tbufdata[MCP_SIDH] = (byte) (canid >> 3);
-        tbufdata[MCP_SIDL] = (byte) ((canid & 0x07) << 5);
-        tbufdata[MCP_EID0] = 0;
-        tbufdata[MCP_EID8] = 0;
-    }
+    mcp2515_id_to_buf(ext,id,tbufdata);
     mcp2515_setRegisterS(mcp_addr, tbufdata, 4);
 }
 
@@ -513,111 +717,193 @@ void MCP_CAN::mcp2515_read_id(const byte mcp_addr, byte* ext, unsigned long* id)
 
     mcp2515_readRegisterS(mcp_addr, tbufdata, 4);
 
-    *id = (tbufdata[MCP_SIDH]<<3) + (tbufdata[MCP_SIDL]>>5);
+    *id = (tbufdata[MCP_SIDH] << 3) + (tbufdata[MCP_SIDL] >> 5);
 
-    if((tbufdata[MCP_SIDL] & MCP_TXB_EXIDE_M) ==  MCP_TXB_EXIDE_M)
+    if ( (tbufdata[MCP_SIDL] & MCP_TXB_EXIDE_M) ==  MCP_TXB_EXIDE_M )
     {
-        // extended id
-        *id = (*id<<2) + (tbufdata[MCP_SIDL] & 0x03);
-        *id = (*id<<8) + tbufdata[MCP_EID8];
-        *id = (*id<<8) + tbufdata[MCP_EID0];
-        *ext = 1;
+      // extended id
+      *id = (*id << 2) + (tbufdata[MCP_SIDL] & 0x03);
+      *id = (*id << 8) + tbufdata[MCP_EID8];
+      *id = (*id << 8) + tbufdata[MCP_EID0];
+      *ext = 1;
     }
 }
 
 /*********************************************************************************************************
 ** Function name:           mcp2515_write_canMsg
 ** Descriptions:            write msg
+**                          Note! There is no check for right address!
 *********************************************************************************************************/
-void MCP_CAN::mcp2515_write_canMsg(const byte buffer_sidh_addr, int rtrBit)
+void MCP_CAN::mcp2515_write_canMsg(const byte buffer_sidh_addr, unsigned long id, byte ext, byte rtrBit, byte len, volatile const byte *buf)
 {
-    byte mcp_addr;
-    mcp_addr = buffer_sidh_addr;
-    mcp2515_setRegisterS(mcp_addr+5, dta, dta_len);                  // write data bytes
-    // Serial.print("RTR: ");
-    // Serial.println(rtrBit);
-    if(rtrBit == 1)                                                   // if RTR set bit in byte
-    {
-        dta_len |= MCP_RTR_MASK;
-    }
-    mcp2515_setRegister((mcp_addr+4), dta_len);                        // write the RTR and DLC
-    mcp2515_write_id(mcp_addr, ext_flg, can_id);                     // write CAN id
+  byte load_addr=txSidhToTxLoad(buffer_sidh_addr);
+  
+  byte tbufdata[4];
+  byte dlc = len | ( rtrBit ? MCP_RTR_MASK : 0 ) ;
+  byte i;
 
+  mcp2515_id_to_buf(ext,id,tbufdata);
+
+#ifdef SPI_HAS_TRANSACTION
+    SPI_BEGIN();
+#endif
+  MCP2515_SELECT();
+  spi_readwrite(load_addr);
+  for (i = 0; i < 4; i++) spi_write(tbufdata[i]);
+  spi_write(dlc);
+  for (i = 0; i < len && i<CAN_MAX_CHAR_IN_MESSAGE; i++) spi_write(buf[i]);
+  
+  MCP2515_UNSELECT();
+#ifdef SPI_HAS_TRANSACTION
+    SPI_END();
+#endif
+  
+  mcp2515_start_transmit( buffer_sidh_addr );
+  
 }
 
 /*********************************************************************************************************
 ** Function name:           mcp2515_read_canMsg
 ** Descriptions:            read message
 *********************************************************************************************************/
-void MCP_CAN::mcp2515_read_canMsg(const byte buffer_sidh_addr)        // read can msg
+void MCP_CAN::mcp2515_read_canMsg( const byte buffer_load_addr, volatile unsigned long *id, volatile byte *ext, volatile byte *rtrBit, volatile byte *len, volatile byte *buf)        /* read can msg                 */
 {
-    byte mcp_addr, ctrl;
+  byte tbufdata[4];
+  byte i;
+  
+  MCP2515_SELECT();
+  spi_readwrite(buffer_load_addr);
+  // mcp2515 has auto-increment of address-pointer
+  for (i = 0; i < 4; i++) tbufdata[i] = spi_read();
+  
+  *rtrBit=(tbufdata[3]&0x08 ? 1 : 0 );
+  
+  *id = (tbufdata[MCP_SIDH] << 3) + (tbufdata[MCP_SIDL] >> 5);
 
-    mcp_addr = buffer_sidh_addr;
-    mcp2515_read_id(mcp_addr, &ext_flg,&can_id);
-    ctrl = mcp2515_readRegister(mcp_addr-1);
-    dta_len = mcp2515_readRegister(mcp_addr+4);
-
-    rtr = (ctrl & 0x08) ? 1 : 0;
-
-    dta_len &= MCP_DLC_MASK;
-    mcp2515_readRegisterS(mcp_addr+5, &(dta[0]), dta_len);
+  if ( (tbufdata[MCP_SIDL] & MCP_TXB_EXIDE_M) ==  MCP_TXB_EXIDE_M )
+  {
+    /* extended id                  */
+    *id = (*id << 2) + (tbufdata[MCP_SIDL] & 0x03);
+    *id = (*id << 8) + tbufdata[MCP_EID8];
+    *id = (*id << 8) + tbufdata[MCP_EID0];
+    *ext = 1;
+  }
+  
+  *len=spi_read() & MCP_DLC_MASK;
+  for (i = 0; i < *len && i<CAN_MAX_CHAR_IN_MESSAGE; i++) {
+    buf[i] = spi_read();
+  }
+  
+  MCP2515_UNSELECT();
 }
 
 /*********************************************************************************************************
 ** Function name:           mcp2515_start_transmit
-** Descriptions:            start transmit
+** Descriptions:            Start message transmit on mcp2515
 *********************************************************************************************************/
 void MCP_CAN::mcp2515_start_transmit(const byte mcp_addr)              // start transmit
 {
-    mcp2515_modifyRegister(mcp_addr-1 , MCP_TXB_TXREQ_M, MCP_TXB_TXREQ_M);
+#ifdef SPI_HAS_TRANSACTION
+    SPI_BEGIN();
+#endif
+  MCP2515_SELECT();
+  spi_readwrite(txSidhToRTS(mcp_addr));
+  MCP2515_UNSELECT();
+#ifdef SPI_HAS_TRANSACTION
+    SPI_END();
+#endif
+}
+
+/*********************************************************************************************************
+** Function name:           mcp2515_isTXBufFree
+** Descriptions:            Test is tx buffer free for transmitting
+*********************************************************************************************************/
+byte MCP_CAN::mcp2515_isTXBufFree(byte *txbuf_n, byte iBuf)           /* get Next free txbuf          */
+{
+  *txbuf_n = 0x00;
+
+  if ( iBuf>=MCP_N_TXBUFFERS || 
+      (mcp2515_readStatus() & txStatusPendingFlag(iBuf))!=0 ) return MCP_ALLTXBUSY;
+  
+  *txbuf_n = txCtrlReg(iBuf) + 1;                                /* return SIDH-address of Buffer */
+  mcp2515_modifyRegister(MCP_CANINTF, txIfFlag(iBuf), 0);
+
+  return MCP2515_OK;
 }
 
 /*********************************************************************************************************
 ** Function name:           mcp2515_getNextFreeTXBuf
-** Descriptions:            get Next free txbuf
+** Descriptions:            finds next free tx buffer for sending. Return MCP_ALLTXBUSY, if there is none.
 *********************************************************************************************************/
 byte MCP_CAN::mcp2515_getNextFreeTXBuf(byte *txbuf_n)                 // get Next free txbuf
 {
-    byte res, i, ctrlval;
-    byte ctrlregs[MCP_N_TXBUFFERS] = { MCP_TXB0CTRL, MCP_TXB1CTRL, MCP_TXB2CTRL };
+    byte status=mcp2515_readStatus() & MCP_STAT_TX_PENDING_MASK;
+    byte i;
 
-    res = MCP_ALLTXBUSY;
     *txbuf_n = 0x00;
+  
+    if ( status==MCP_STAT_TX_PENDING_MASK ) return MCP_ALLTXBUSY; // All buffers are pending
 
-    // check all 3 TX-Buffers
-    for(i=0; i<MCP_N_TXBUFFERS; i++)
+    // check all 3 TX-Buffers except reserved
+    for (i = 0; i < MCP_N_TXBUFFERS-nReservedTx; i++)
     {
-        ctrlval = mcp2515_readRegister(ctrlregs[i]);
-        if((ctrlval & MCP_TXB_TXREQ_M) == 0) {
-            *txbuf_n = ctrlregs[i]+1;                                   // return SIDH-address of Buffer
-            res = MCP2515_OK;
-            return res;                                                 // ! function exit
-        }
+      if ( (status & txStatusPendingFlag(i) ) == 0 ) {
+        *txbuf_n = txCtrlReg(i) + 1;                                   // return SIDH-address of Buffer
+        mcp2515_modifyRegister(MCP_CANINTF, txIfFlag(i), 0);
+        return MCP2515_OK;                                                 // ! function exit
+      }
     }
-    return res;
+  
+    return MCP_ALLTXBUSY;
+}
+
+/*********************************************************************************************************
+** Function name:           MCP_CAN
+** Descriptions:            Constructor
+*********************************************************************************************************/
+MCP_CAN::MCP_CAN(byte _CS) : nReservedTx(0)
+{
+  pSPI=&SPI; init_CS(_CS);
 }
 
 /*********************************************************************************************************
 ** Function name:           set CS
 ** Descriptions:            init CS pin and set UNSELECTED
 *********************************************************************************************************/
-MCP_CAN::MCP_CAN(byte _CS)
+void MCP_CAN::init_CS(byte _CS)
 {
-    SPICS = _CS;
+  if (_CS == 0) return;
+  SPICS = _CS;
+  pinMode(SPICS, OUTPUT);
+  MCP2515_UNSELECT();
 }
 
 /*********************************************************************************************************
-** Function name:           init
+** Function name:           begin
 ** Descriptions:            init can and set speed
 *********************************************************************************************************/
-byte MCP_CAN::begin(byte speedset)
+byte MCP_CAN::begin(byte speedset, const byte clockset)
 {
-    pinMode(SPICS, OUTPUT);
-    MCP2515_UNSELECT();
-    SPI.begin();
-    byte res = mcp2515_init(speedset);
+    pSPI->begin();
+    byte res = mcp2515_init(speedset, clockset);
     return ((res == MCP2515_OK) ? CAN_OK : CAN_FAILINIT);
+}
+
+/*********************************************************************************************************
+** Function name:           enableTxInterrupt
+** Descriptions:            enable interrupt for all tx buffers
+*********************************************************************************************************/
+void MCP_CAN::enableTxInterrupt(bool enable)
+{
+  byte interruptStatus=mcp2515_readRegister(MCP_CANINTE);
+
+  if ( enable ) {
+    interruptStatus |= MCP_TX_INT;
+  } else {
+    interruptStatus &= ~MCP_TX_INT;
+  }
+  
+  mcp2515_setRegister(MCP_CANINTE, interruptStatus);
 }
 
 /*********************************************************************************************************
@@ -633,7 +919,7 @@ byte MCP_CAN::init_Mask(byte num, byte ext, unsigned long ulData)
     delay(10);
 #endif
     res = mcp2515_setCANCTRL_Mode(MODE_CONFIG);
-    if(res > 0){
+    if (res > 0) {
 #if DEBUG_EN
         Serial.print("Enter setting mode fall\r\n");
 #else
@@ -642,17 +928,17 @@ byte MCP_CAN::init_Mask(byte num, byte ext, unsigned long ulData)
         return res;
     }
 
-    if(num == 0){
+    if (num == 0) {
         mcp2515_write_id(MCP_RXM0SIDH, ext, ulData);
 
     }
-    else if(num == 1){
+    else if (num == 1) {
         mcp2515_write_id(MCP_RXM1SIDH, ext, ulData);
     }
     else res =  MCP2515_FAIL;
 
     res = mcp2515_setCANCTRL_Mode(MODE_NORMAL);
-    if(res > 0){
+    if (res > 0) {
 #if DEBUG_EN
         Serial.print("Enter normal mode fall\r\n");
 #else
@@ -681,7 +967,7 @@ byte MCP_CAN::init_Filt(byte num, byte ext, unsigned long ulData)
     delay(10);
 #endif
     res = mcp2515_setCANCTRL_Mode(MODE_CONFIG);
-    if(res > 0)
+    if (res > 0)
     {
 #if DEBUG_EN
         Serial.print("Enter setting mode fall\r\n");
@@ -691,38 +977,38 @@ byte MCP_CAN::init_Filt(byte num, byte ext, unsigned long ulData)
         return res;
     }
 
-    switch(num)
+    switch ( num )
     {
-        case 0:
+      case 0:
         mcp2515_write_id(MCP_RXF0SIDH, ext, ulData);
         break;
 
-        case 1:
+      case 1:
         mcp2515_write_id(MCP_RXF1SIDH, ext, ulData);
         break;
 
-        case 2:
+      case 2:
         mcp2515_write_id(MCP_RXF2SIDH, ext, ulData);
         break;
 
-        case 3:
+      case 3:
         mcp2515_write_id(MCP_RXF3SIDH, ext, ulData);
         break;
 
-        case 4:
+      case 4:
         mcp2515_write_id(MCP_RXF4SIDH, ext, ulData);
         break;
 
-        case 5:
+      case 5:
         mcp2515_write_id(MCP_RXF5SIDH, ext, ulData);
         break;
 
-        default:
+      default:
         res = MCP2515_FAIL;
     }
 
     res = mcp2515_setCANCTRL_Mode(MODE_NORMAL);
-    if(res > 0)
+    if (res > 0)
     {
 #if DEBUG_EN
         Serial.print("Enter normal mode fall\r\nSet filter fail!!\r\n");
@@ -741,85 +1027,82 @@ byte MCP_CAN::init_Filt(byte num, byte ext, unsigned long ulData)
 }
 
 /*********************************************************************************************************
-** Function name:           setMsg
-** Descriptions:            set can message, such as dlc, id, dta[] and so on
+** Function name:           sendMsgBuf
+** Descriptions:            Send message by using buffer read as free from CANINTF status
+**                          Status has to be read with readRxTxStatus and filtered with checkClearTxStatus
 *********************************************************************************************************/
-byte MCP_CAN::setMsg(unsigned long id, byte ext, byte len, byte rtr, byte *pData)
+byte MCP_CAN::sendMsgBuf(byte status, unsigned long id, byte ext, byte rtrBit, byte len, volatile const byte *buf)
 {
-    ext_flg     = ext;
-    can_id      = id;
-    dta_len     = min(len, MAX_CHAR_IN_MESSAGE);
-    rtr         = rtr;
-    for(int i = 0; i<dta_len; i++)
-    {
-        dta[i] = *(pData+i);
-    }
-    return MCP2515_OK;
-}
+  byte txbuf_n=statusToTxSidh(status);
+  
+  if ( txbuf_n==0 ) return CAN_FAILTX; // Invalid status
+  
+  mcp2515_modifyRegister(MCP_CANINTF, status, 0);  // Clear interrupt flag
+  mcp2515_write_canMsg(txbuf_n, id, ext, rtrBit, len, buf);
 
-
-/*********************************************************************************************************
-** Function name:           setMsg
-** Descriptions:            set can message, such as dlc, id, dta[] and so on
-*********************************************************************************************************/
-byte MCP_CAN::setMsg(unsigned long id, byte ext, byte len, byte *pData)
-{
-    return setMsg(id, ext, len, 0, pData);
+  return CAN_OK;
 }
 
 /*********************************************************************************************************
-** Function name:           clearMsg
-** Descriptions:            set all message to zero
+** Function name:           trySendMsgBuf
+** Descriptions:            Try to send message. There is no delays for waiting free buffer.
 *********************************************************************************************************/
-byte MCP_CAN::clearMsg()
+byte MCP_CAN::trySendMsgBuf(unsigned long id, byte ext, byte rtrBit, byte len, const byte *buf, byte iTxBuf)
 {
-    can_id      = 0;
-    dta_len     = 0;
-    ext_flg     = 0;
-    rtr         = 0;
-    filhit      = 0;
+  byte txbuf_n;
 
-    for(int i = 0; i<dta_len; i++)
-    {
-        dta[i] = 0x00;
-    }
+  if ( iTxBuf<MCP_N_TXBUFFERS ) { // Use specified buffer
+    if ( mcp2515_isTXBufFree(&txbuf_n,iTxBuf) != MCP2515_OK ) return CAN_FAILTX;
+  } else {
+    if ( mcp2515_getNextFreeTXBuf(&txbuf_n) != MCP2515_OK ) return CAN_FAILTX;
+  }
 
-    return MCP2515_OK;
+  mcp2515_write_canMsg(txbuf_n, id, ext, rtrBit, len, buf);
+  
+  return CAN_OK;
 }
 
 /*********************************************************************************************************
 ** Function name:           sendMsg
 ** Descriptions:            send message
 *********************************************************************************************************/
-byte MCP_CAN::sendMsg(int rtrBit)
+byte MCP_CAN::sendMsg(unsigned long id, byte ext, byte rtrBit, byte len, const byte *buf, bool wait_sent)
 {
     byte res, res1, txbuf_n;
     uint16_t uiTimeOut = 0;
 
+    can_id=id;
+    ext_flg=ext;
+    rtr=rtrBit;
+    
     do {
+        if (uiTimeOut > 0) delayMicroseconds(10);
         res = mcp2515_getNextFreeTXBuf(&txbuf_n);                       // info = addr.
         uiTimeOut++;
     } while (res == MCP_ALLTXBUSY && (uiTimeOut < TIMEOUTVALUE));
 
-    if(uiTimeOut == TIMEOUTVALUE)
+    if (uiTimeOut == TIMEOUTVALUE)
     {
         return CAN_GETTXBFTIMEOUT;                                      // get tx buff time out
     }
+    mcp2515_write_canMsg(txbuf_n, id, ext, rtrBit, len, buf);
 
-    uiTimeOut = 0;
-    mcp2515_write_canMsg(txbuf_n, rtrBit);
-    mcp2515_start_transmit(txbuf_n);
+    if (wait_sent) {
+      uiTimeOut = 0;
+      do
+      {
+        if (uiTimeOut > 0) delayMicroseconds(10);
+          uiTimeOut++;
+          res1 = mcp2515_readRegister(txbuf_n - 1);  // read send buff ctrl reg
+          res1 = res1 & 0x08;
+      } while (res1 && (uiTimeOut < TIMEOUTVALUE));
 
-    do {
-        uiTimeOut++;
-        res1= mcp2515_readRegister(txbuf_n-1 /* the ctrl reg is located at txbuf_n-1 */);  // read send buff ctrl reg
-        res1 = res1 & 0x08;
-    }while(res1 && (uiTimeOut < TIMEOUTVALUE));
-
-    if(uiTimeOut == TIMEOUTVALUE)                                       // send msg timeout
-    {
-        return CAN_SENDMSGTIMEOUT;
+      if (uiTimeOut == TIMEOUTVALUE)                                       // send msg timeout
+      {
+          return CAN_SENDMSGTIMEOUT;
+      }
     }
+
     return CAN_OK;
 
 }
@@ -828,53 +1111,20 @@ byte MCP_CAN::sendMsg(int rtrBit)
 ** Function name:           sendMsgBuf
 ** Descriptions:            send buf
 *********************************************************************************************************/
-byte MCP_CAN::sendMsgBuf(unsigned long id, byte ext, byte rtr, byte len, byte *buf)
+byte MCP_CAN::sendMsgBuf(unsigned long id, byte ext, byte rtrBit, byte len, const byte *buf, bool wait_sent)
 {
-    setMsg(id, ext, len, rtr, buf);
-    // Serial.print("RTR00: ");
-    // Serial.println(rtr, HEX);
-    return sendMsg(rtr);
+    return sendMsg(id,ext,rtrBit,len,buf,wait_sent);
 }
 
 /*********************************************************************************************************
 ** Function name:           sendMsgBuf
 ** Descriptions:            send buf
 *********************************************************************************************************/
-byte MCP_CAN::sendMsgBuf(unsigned long id, byte ext, byte len, byte *buf)
+byte MCP_CAN::sendMsgBuf(unsigned long id, byte ext, byte len, const byte *buf, bool wait_sent)
 {
-    setMsg(id, ext, len, buf);
-    return sendMsg(0);
+    return sendMsg(id,ext,0,len,buf,wait_sent);
 }
 
-
-/*********************************************************************************************************
-** Function name:           readMsg
-** Descriptions:            read message
-*********************************************************************************************************/
-byte MCP_CAN::readMsg()
-{
-    byte stat, res;
-
-    stat = mcp2515_readStatus();
-
-    if(stat & MCP_STAT_RX0IF)                                        // Msg in Buffer 0
-    {
-        mcp2515_read_canMsg(MCP_RXBUF_0);
-        mcp2515_modifyRegister(MCP_CANINTF, MCP_RX0IF, 0);
-        res = CAN_OK;
-    }
-    else if(stat & MCP_STAT_RX1IF)                                   // Msg in Buffer 1
-    {
-        mcp2515_read_canMsg(MCP_RXBUF_1);
-        mcp2515_modifyRegister(MCP_CANINTF, MCP_RX1IF, 0);
-        res = CAN_OK;
-    }
-    else
-    {
-        res = CAN_NOMSG;
-    }
-    return res;
-}
 
 /*********************************************************************************************************
 ** Function name:           readMsgBuf
@@ -882,20 +1132,7 @@ byte MCP_CAN::readMsg()
 *********************************************************************************************************/
 byte MCP_CAN::readMsgBuf(byte *len, byte buf[])
 {
-    byte  rc;
-
-    rc = readMsg();
-
-    if(rc == CAN_OK) {
-        *len = dta_len;
-        for(int i = 0; i<dta_len; i++)
-        {
-            buf[i] = dta[i];
-        }
-    } else {
-        *len = 0;
-    }
-    return rc;
+    return readMsgBufID(readRxTxStatus(),&can_id,&ext_flg,&rtr,len,buf);
 }
 
 /*********************************************************************************************************
@@ -904,20 +1141,112 @@ byte MCP_CAN::readMsgBuf(byte *len, byte buf[])
 *********************************************************************************************************/
 byte MCP_CAN::readMsgBufID(unsigned long *ID, byte *len, byte buf[])
 {
-    byte rc;
-    rc = readMsg();
+    return readMsgBufID(readRxTxStatus(),ID,&ext_flg,&rtr,len,buf);
+}
 
-    if(rc == CAN_OK) {
-        *len = dta_len;
-        *ID  = can_id;
-        for(int i = 0; i<dta_len && i < MAX_CHAR_IN_MESSAGE; i++)
-        {
-            buf[i] = dta[i];
-        }
-    } else {
-        *len = 0;
-    }
-    return rc;
+/*********************************************************************************************************
+** Function name:           readMsgBufID
+** Descriptions:            Read message buf and can bus source ID according to status.
+**                          Status has to be read with readRxTxStatus.
+*********************************************************************************************************/
+byte MCP_CAN::readMsgBufID(byte status, volatile unsigned long *id, volatile byte *ext, volatile byte *rtrBit, volatile byte *len, volatile byte *buf) 
+{
+  byte rc=CAN_NOMSG;
+  
+  if ( status & MCP_RX0IF )                                        // Msg in Buffer 0
+  {
+    mcp2515_read_canMsg( MCP_READ_RX0, id, ext, rtrBit, len, buf);
+    rc = CAN_OK;
+  }
+  else if ( status & MCP_RX1IF )                                   // Msg in Buffer 1
+  {
+    mcp2515_read_canMsg( MCP_READ_RX1, id, ext, rtrBit, len, buf);
+    rc = CAN_OK;
+  }
+
+  if (rc==CAN_OK) {
+    rtr=*rtrBit;
+    // dta_len=*len; // not used on any interface function
+    ext_flg=*ext;
+    can_id=*id;
+  } else {
+    *len=0;
+  }
+  
+  return rc;
+}
+
+/*********************************************************************************************************
+** Function name:           readRxTxStatus
+** Descriptions:            Read RX and TX interrupt bits. Function uses status reading, but translates.
+**                          result to MCP_CANINTF. With this you can check status e.g. on interrupt sr
+**                          with one single call to save SPI calls. Then use checkClearRxStatus and
+**                          checkClearTxStatus for testing. 
+*********************************************************************************************************/
+byte MCP_CAN::readRxTxStatus(void)
+{
+  byte ret=( mcp2515_readStatus() & ( MCP_STAT_TXIF_MASK | MCP_STAT_RXIF_MASK ) );
+  ret=(ret & MCP_STAT_TX0IF ? MCP_TX0IF : 0) | 
+      (ret & MCP_STAT_TX1IF ? MCP_TX1IF : 0) | 
+      (ret & MCP_STAT_TX2IF ? MCP_TX2IF : 0) | 
+      (ret & MCP_STAT_RXIF_MASK); // Rx bits happend to be same on status and MCP_CANINTF
+  return ret;                
+}
+
+/*********************************************************************************************************
+** Function name:           checkClearRxStatus
+** Descriptions:            Return first found rx CANINTF status and clears it from parameter.
+**                          Note that this does not affect to chip CANINTF at all. You can use this 
+**                          with one single readRxTxStatus call.
+*********************************************************************************************************/
+byte MCP_CAN::checkClearRxStatus(byte *status)
+{
+  byte ret;
+  
+  ret = *status & MCP_RX0IF; *status &= ~MCP_RX0IF;
+  
+  if ( ret==0 ) { ret = *status & MCP_RX1IF; *status &= ~MCP_RX1IF; }
+
+  return ret;                
+}
+
+/*********************************************************************************************************
+** Function name:           checkClearTxStatus
+** Descriptions:            Return specified buffer of first found tx CANINTF status and clears it from parameter.
+**                          Note that this does not affect to chip CANINTF at all. You can use this 
+**                          with one single readRxTxStatus call.
+*********************************************************************************************************/
+byte MCP_CAN::checkClearTxStatus(byte *status, byte iTxBuf)
+{
+  byte ret;
+  
+  if ( iTxBuf<MCP_N_TXBUFFERS ) { // Clear specific buffer flag
+    ret = *status & txIfFlag(iTxBuf); *status &= ~txIfFlag(iTxBuf);
+  } else {
+    ret=0;
+    for (byte i = 0; i < MCP_N_TXBUFFERS-nReservedTx; i++) {
+      ret = *status & txIfFlag(i); 
+      if ( ret!=0 ) {
+        *status &= ~txIfFlag(i);
+        return ret;
+      }
+    };
+  }
+
+  return ret;                
+}
+
+/*********************************************************************************************************
+** Function name:           clearBufferTransmitIfFlags
+** Descriptions:            Clear transmit interrupt flags for specific buffer or for all unreserved buffers.
+**                          If interrupt will be used, it is important to clear all flags, when there is no
+**                          more data to be sent. Otherwise IRQ will newer change state.
+*********************************************************************************************************/
+void MCP_CAN::clearBufferTransmitIfFlags(byte flags)
+{ 
+  flags &= MCP_TX_INT;
+  if ( flags==0 ) return;
+  mcp2515_modifyRegister(MCP_CANINTF, flags, 0);
 }
 
 /*********************************************************************************************************
@@ -943,7 +1272,7 @@ byte MCP_CAN::checkError(void)
 
 /*********************************************************************************************************
 ** Function name:           getCanId
-** Descriptions:            when receive something you can get the can id!!
+** Descriptions:            when receive something, you can get the can id!!
 *********************************************************************************************************/
 unsigned long MCP_CAN::getCanId(void)
 {
@@ -952,7 +1281,7 @@ unsigned long MCP_CAN::getCanId(void)
 
 /*********************************************************************************************************
 ** Function name:           isRemoteRequest
-** Descriptions:            when receive something you can check if it was a request
+** Descriptions:            when receive something, you can check if it was a request
 *********************************************************************************************************/
 byte MCP_CAN::isRemoteRequest(void)
 {

--- a/mcp_can.h
+++ b/mcp_can.h
@@ -54,7 +54,7 @@
 class MCP_CAN
 {
     private:
-    
+
     byte   ext_flg;                         // identifier xxxID
                                             // either extended (the 29 LSB) or standard (the 11 LSB)
     unsigned long  can_id;                  // can id
@@ -72,7 +72,7 @@ private:
     void mcp2515_reset(void);                                   // reset mcp2515
 
     byte mcp2515_readRegister(const byte address);              // read mcp2515's register
-    
+
     void mcp2515_readRegisterS(const byte address,
 	                       byte values[],
                                const byte n);
@@ -82,9 +82,9 @@ private:
     void mcp2515_setRegisterS(const byte address,               // set mcp2515's registers
                               const byte values[],
                               const byte n);
-    
+
     void mcp2515_initCANBuffers(void);
-    
+
     void mcp2515_modifyRegister(const byte address,             // set bit of one register
                                 const byte mask,
                                 const byte data);
@@ -119,9 +119,9 @@ public:
     void init_CS(byte _CS);                      // define CS after construction before begin()
     void setSPI(SPIClass *_pSPI) { pSPI=_pSPI; } // define SPI port to use before begin()
     void enableTxInterrupt(bool enable=true);    // enable transmit interrupt
-    void reserveTxBuffers(byte nTxBuf=0) { nReservedTx=(nTxBuf<MCP_N_TXBUFFERS?nTxBuf:MCP_N_TXBUFFERS-1); }  
+    void reserveTxBuffers(byte nTxBuf=0) { nReservedTx=(nTxBuf<MCP_N_TXBUFFERS?nTxBuf:MCP_N_TXBUFFERS-1); }
     byte getLastTxBuffer() { return MCP_N_TXBUFFERS-1; } // read index of last tx buffer
-    
+
     byte begin(byte speedset, const byte clockset = MCP_16MHz);     // init can
     byte init_Mask(byte num, byte ext, unsigned long ulData);       // init Masks
     byte init_Filt(byte num, byte ext, unsigned long ulData);       // init filters
@@ -148,7 +148,7 @@ public:
     byte readRxTxStatus(void);                                      // read has something send or received
     byte checkClearRxStatus(byte *status);                          // read and clear and return first found rx status bit
     byte checkClearTxStatus(byte *status, byte iTxBuf=0xff);        // read and clear and return first found or buffer specified tx status bit
-    
+
 };
 
 #endif

--- a/mcp_can.h
+++ b/mcp_can.h
@@ -20,6 +20,7 @@
   Adlerweb
   Btetz
   Hurvajs
+  ttlappalainen
 
   The MIT License (MIT)
 
@@ -53,15 +54,14 @@
 class MCP_CAN
 {
     private:
-
+    
     byte   ext_flg;                         // identifier xxxID
                                             // either extended (the 29 LSB) or standard (the 11 LSB)
     unsigned long  can_id;                  // can id
-    byte   dta_len;                         // data length
-    byte   dta[MAX_CHAR_IN_MESSAGE];        // data
     byte   rtr;                             // rtr
-    byte   filhit;
     byte   SPICS;
+    SPIClass *pSPI;
+    byte   nReservedTx;                     // Count of tx buffers for reserved send
 
 /*
 *  mcp2515 driver function
@@ -72,7 +72,7 @@ private:
     void mcp2515_reset(void);                                   // reset mcp2515
 
     byte mcp2515_readRegister(const byte address);              // read mcp2515's register
-
+    
     void mcp2515_readRegisterS(const byte address,
 	                       byte values[],
                                const byte n);
@@ -82,17 +82,17 @@ private:
     void mcp2515_setRegisterS(const byte address,               // set mcp2515's registers
                               const byte values[],
                               const byte n);
-
+    
     void mcp2515_initCANBuffers(void);
-
+    
     void mcp2515_modifyRegister(const byte address,             // set bit of one register
                                 const byte mask,
                                 const byte data);
 
     byte mcp2515_readStatus(void);                              // read mcp2515's Status
     byte mcp2515_setCANCTRL_Mode(const byte newmode);           // set mode
-    byte mcp2515_configRate(const byte canSpeed);               // set boadrate
-    byte mcp2515_init(const byte canSpeed);                     // mcp2515init
+    byte mcp2515_configRate(const byte canSpeed, const byte clock);  // set baudrate
+    byte mcp2515_init(const byte canSpeed, const byte clock);   // mcp2515init
 
     void mcp2515_write_id( const byte mcp_addr,                 // write can id
                                const byte ext,
@@ -102,28 +102,31 @@ private:
                                     byte* ext,
                                     unsigned long* id );
 
-    void mcp2515_write_canMsg( const byte buffer_sidh_addr, int rtrBit );   // write can msg
-    void mcp2515_read_canMsg( const byte buffer_sidh_addr);     // read can msg
+    void mcp2515_write_canMsg( const byte buffer_sidh_addr, unsigned long id, byte ext, byte rtr, byte len, volatile const byte *buf);     // read can msg
+    void mcp2515_read_canMsg( const byte buffer_load_addr, volatile unsigned long *id, volatile byte *ext, volatile byte *rtr, volatile byte *len, volatile byte *buf);   // write can msg
     void mcp2515_start_transmit(const byte mcp_addr);           // start transmit
     byte mcp2515_getNextFreeTXBuf(byte *txbuf_n);               // get Next free txbuf
+    byte mcp2515_isTXBufFree(byte *txbuf_n, byte iBuf);         // is buffer by index free
 
 /*
 *  can operator function
 */
 
-    byte setMsg(unsigned long id, byte ext, byte len, byte rtr, byte *pData);   // set message
-    byte setMsg(unsigned long id, byte ext, byte len, byte *pData);             //  set message
-    byte clearMsg();                                                // clear all message to zero
-    byte readMsg();                                                 // read message
-    byte sendMsg(int rtrBit);                                                 // send message
+    byte sendMsg(unsigned long id, byte ext, byte rtrBit, byte len, const byte *buf, bool wait_sent=true); // send message
 
 public:
-    MCP_CAN(byte _CS);
-    byte begin(byte speedset);                                      // init can
+    MCP_CAN(byte _CS=0);
+    void init_CS(byte _CS);                      // define CS after construction before begin()
+    void setSPI(SPIClass *_pSPI) { pSPI=_pSPI; } // define SPI port to use before begin()
+    void enableTxInterrupt(bool enable=true);    // enable transmit interrupt
+    void reserveTxBuffers(byte nTxBuf=0) { nReservedTx=(nTxBuf<MCP_N_TXBUFFERS?nTxBuf:MCP_N_TXBUFFERS-1); }  
+    byte getLastTxBuffer() { return MCP_N_TXBUFFERS-1; } // read index of last tx buffer
+    
+    byte begin(byte speedset, const byte clockset = MCP_16MHz);     // init can
     byte init_Mask(byte num, byte ext, unsigned long ulData);       // init Masks
     byte init_Filt(byte num, byte ext, unsigned long ulData);       // init filters
-    byte sendMsgBuf(unsigned long id, byte ext, byte rtr, byte len, byte *buf);     // send buf
-    byte sendMsgBuf(unsigned long id, byte ext, byte len, byte *buf);               // send buf
+    byte sendMsgBuf(unsigned long id, byte ext, byte rtrBit, byte len, const byte *buf, bool wait_sent=true);  // send buf
+    byte sendMsgBuf(unsigned long id, byte ext, byte len, const byte *buf, bool wait_sent=true);               // send buf
     byte readMsgBuf(byte *len, byte *buf);                          // read buf
     byte readMsgBufID(unsigned long *ID, byte *len, byte *buf);     // read buf with object ID
     byte checkReceive(void);                                        // if something received
@@ -131,6 +134,21 @@ public:
     unsigned long getCanId(void);                                   // get can id when receive
     byte isRemoteRequest(void);                                     // get RR flag when receive
     byte isExtendedFrame(void);                                     // did we recieve 29bit frame?
+
+    byte readMsgBufID(byte status, volatile unsigned long *id, volatile byte *ext, volatile byte *rtr, volatile byte *len, volatile byte *buf); // read buf with object ID
+    byte trySendMsgBuf(unsigned long id, byte ext, byte rtrBit, byte len, const byte *buf, byte iTxBuf=0xff);  // as sendMsgBuf, but does not have any wait for free buffer
+    byte sendMsgBuf(byte status, unsigned long id, byte ext, byte rtrBit, byte len, volatile const byte *buf); // send message buf by using parsed buffer status
+    inline byte trySendExtMsgBuf(unsigned long id, byte len, const byte *buf, byte iTxBuf=0xff) {  // as trySendMsgBuf, but set ext=1 and rtr=0
+      return trySendMsgBuf(id,1,0,len,buf,iTxBuf);
+    }
+    inline byte sendExtMsgBuf(byte status, unsigned long id, byte len, volatile const byte *buf) { // as sendMsgBuf, but set ext=1 and rtr=0
+      return sendMsgBuf(status,id,1,0,len,buf);
+    }
+    void clearBufferTransmitIfFlags(byte flags=0);                  // Clear transmit flags according to status
+    byte readRxTxStatus(void);                                      // read has something send or received
+    byte checkClearRxStatus(byte *status);                          // read and clear and return first found rx status bit
+    byte checkClearTxStatus(byte *status, byte iTxBuf=0xff);        // read and clear and return first found or buffer specified tx status bit
+    
 };
 
 #endif

--- a/mcp_can_dfs.h
+++ b/mcp_can_dfs.h
@@ -4,9 +4,9 @@
 
   Author:Loovee (loovee@seeed.cc)
   2014-1-16
-  
-  Contributor: 
-  
+
+  Contributor:
+
   Cory J. Fowler
   Latonita
   Woodward1
@@ -21,7 +21,8 @@
   Btetz
   Hurvajs
   xboxpro1
-  
+  ttlappalainen
+
   The MIT License (MIT)
 
   Copyright (c) 2013 Seeed Technology Inc.
@@ -85,10 +86,18 @@
 #define MCP_TXB_TXIE_M      0x04
 #define MCP_TXB_TXP10_M     0x03
 
-#define MCP_TXB_RTR_M       0x40                                        // In TXBnDLC                  
-#define MCP_RXB_IDE_M       0x08                                        // In RXBnSIDL                 
-#define MCP_RXB_RTR_M       0x40                                        // In RXBnDLC                   
+#define MCP_TXB_RTR_M       0x40                                        // In TXBnDLC
+#define MCP_RXB_IDE_M       0x08                                        // In RXBnSIDL
+#define MCP_RXB_RTR_M       0x40                                        // In RXBnDLC
 
+#define MCP_STAT_TX_PENDING_MASK (0x54)
+#define MCP_STAT_TX0_PENDING (0x04)
+#define MCP_STAT_TX1_PENDING (0x10)
+#define MCP_STAT_TX2_PENDING (0x40)
+#define MCP_STAT_TXIF_MASK   (0xA8)
+#define MCP_STAT_TX0IF       (0x08)
+#define MCP_STAT_TX1IF       (0x20)
+#define MCP_STAT_TX2IF       (0x80)
 #define MCP_STAT_RXIF_MASK   (0x03)
 #define MCP_STAT_RX0IF (1<<0)
 #define MCP_STAT_RX1IF (1<<1)
@@ -101,7 +110,7 @@
 #define MCP_EFLG_TXWAR  (1<<2)
 #define MCP_EFLG_RXWAR  (1<<1)
 #define MCP_EFLG_EWARN  (1<<0)
-#define MCP_EFLG_ERRORMASK  (0xF8)                                      // 5 MS-Bits                    
+#define MCP_EFLG_ERRORMASK  (0xF8)                                      // 5 MS-Bits
 
 // Define MCP2515 register addresses
 
@@ -148,12 +157,16 @@
 #define MCP_CANINTF     0x2C
 #define MCP_EFLG        0x2D
 #define MCP_TXB0CTRL    0x30
+#define MCP_TXB0SIDH    0x31
 #define MCP_TXB1CTRL    0x40
+#define MCP_TXB1SIDH    0x41
 #define MCP_TXB2CTRL    0x50
+#define MCP_TXB2SIDH    0x51
 #define MCP_RXB0CTRL    0x60
 #define MCP_RXB0SIDH    0x61
 #define MCP_RXB1CTRL    0x70
 #define MCP_RXB1SIDH    0x71
+
 #define MCP_TX_INT      0x1C                                    // Enable all transmit interrup ts
 #define MCP_TX01_INT    0x0C                                    // Enable TXB0 and TXB1 interru pts
 #define MCP_RX_INT      0x03                                    // Enable receive interrupts
@@ -236,6 +249,11 @@
 #define MCP_WAKIF       0x40
 #define MCP_MERRF       0x80
 
+// clock
+
+#define MCP_16MHz	1
+#define MCP_8MHz	2
+
 // speed 16M
 
 #define MCP_16MHz_1000kBPS_CFG1 (0x00)
@@ -311,6 +329,60 @@
 #define MCP_16MHz_666kBPS_CFG3 (0x04)
 
 
+// speed 8M
+
+#define MCP_8MHz_1000kBPS_CFG1 (0x00)
+#define MCP_8MHz_1000kBPS_CFG2 (0x80)
+#define MCP_8MHz_1000kBPS_CFG3 (0x00)
+
+#define MCP_8MHz_500kBPS_CFG1 (0x00)
+#define MCP_8MHz_500kBPS_CFG2 (0x90)
+#define MCP_8MHz_500kBPS_CFG3 (0x02)
+
+#define MCP_8MHz_250kBPS_CFG1 (0x00)
+#define MCP_8MHz_250kBPS_CFG2 (0xb1)
+#define MCP_8MHz_250kBPS_CFG3 (0x05)
+
+#define MCP_8MHz_200kBPS_CFG1 (0x00)
+#define MCP_8MHz_200kBPS_CFG2 (0xb4)
+#define MCP_8MHz_200kBPS_CFG3 (0x06)
+
+#define MCP_8MHz_125kBPS_CFG1 (0x01)
+#define MCP_8MHz_125kBPS_CFG2 (0xb1)
+#define MCP_8MHz_125kBPS_CFG3 (0x05)
+
+#define MCP_8MHz_100kBPS_CFG1 (0x01)
+#define MCP_8MHz_100kBPS_CFG2 (0xb4)
+#define MCP_8MHz_100kBPS_CFG3 (0x06)
+
+#define MCP_8MHz_80kBPS_CFG1 (0x01)
+#define MCP_8MHz_80kBPS_CFG2 (0xbf)
+#define MCP_8MHz_80kBPS_CFG3 (0x07)
+
+#define MCP_8MHz_50kBPS_CFG1 (0x03)
+#define MCP_8MHz_50kBPS_CFG2 (0xb4)
+#define MCP_8MHz_50kBPS_CFG3 (0x06)
+
+#define MCP_8MHz_40kBPS_CFG1 (0x03)
+#define MCP_8MHz_40kBPS_CFG2 (0xbf)
+#define MCP_8MHz_40kBPS_CFG3 (0x07)
+
+#define MCP_8MHz_31k25BPS_CFG1 (0x07)
+#define MCP_8MHz_31k25BPS_CFG2 (0xa4)
+#define MCP_8MHz_31k25BPS_CFG3 (0x04)
+
+#define MCP_8MHz_20kBPS_CFG1 (0x07)
+#define MCP_8MHz_20kBPS_CFG2 (0xbf)
+#define MCP_8MHz_20kBPS_CFG3 (0x07)
+
+#define MCP_8MHz_10kBPS_CFG1 (0x0f)
+#define MCP_8MHz_10kBPS_CFG2 (0xbf)
+#define MCP_8MHz_10kBPS_CFG3 (0x07)
+
+#define MCP_8MHz_5kBPS_CFG1 (0x1f)
+#define MCP_8MHz_5kBPS_CFG2 (0xbf)
+#define MCP_8MHz_5kBPS_CFG3 (0x07)
+
 #define MCPDEBUG        (0)
 #define MCPDEBUG_TXBUF  (0)
 #define MCP_N_TXBUFFERS (3)
@@ -329,7 +401,7 @@
 
 #define CANUSELOOP 0
 
-#define CANSENDTIMEOUT (200)                                            // milliseconds                 
+#define CANSENDTIMEOUT (200)                                            // milliseconds
 
 
 // initial value of gCANAutoProcess
@@ -345,7 +417,7 @@
 #define CAN_5KBPS           1
 #define CAN_10KBPS          2
 #define CAN_20KBPS          3
-#define CAN_25KBPS          4 
+#define CAN_25KBPS          4
 #define CAN_31K25BPS        5
 #define CAN_33KBPS          6
 #define CAN_40KBPS          7


### PR DESCRIPTION
Hi,

I made several improvements for you library and hope you could update them. I take care of NMEA2000 library and these changes are important, so that it can be used. Now library users sometimes mixes the original version, since for connecting they often use your CAN BUS shield. The library should be still completely backward compatibility and I tested it with your examples.

The biggest change is on mcp2515_write_canMsg and mcp2515_read_canMsg. And because of those I removed some unnecessary private data and functions. That is the main reason for big differences. With these changes I managed to minimize SPI communication so that library communication time dropped half of original.

Note also that with this version I can have full and fast two direction interrupt handled system.

- Backward compatibility should be OK - tested with read and write examples
- mcp2515_write_canMsg and mcp2515_read_canMsg does transfer now with single SPI session by using SPI READ RX BUFFER and LOAD TX BUFFER
- mcp2515_start_transmit uses directly SPI instruction RTS
- removed internal data buffer. Read and write uses directly provided buffer
- works with 8Mhz clock
- Possible to set SPI. Some boards has 2 SPI!
- Works with NMEA2000 library
- New functions for better interrupt handling
