### PR TITLE
Add library.properties for recognition by the Library Manager

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=mcp_can
+version=1.20
+author=loovee <luweicong@seeed.cc>
+maintainer=Seeed Development Limited
+sentence=Library provides CAN communication on the CAN-Bus Shield.
+paragraph=Created for the Seeed Studio CAN BUS Shield for Arduino Devices.  Should work for MCP2515 & MCP2551 chips.
+category=Communication
+url=https://github.com/Seeed-Studio/CAN_BUS_Shield
+architectures=*
+includes=mcp_can.h


### PR DESCRIPTION
Add library.properties for recognition by the Library Manager.

For more information on the Arduino IDE Library Manager see https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ.

Note: Adding this is useful for installing a folder or .zip file into the library manager even without this being published to be search-discoverable on the library manager.