### PR TITLE
Keep custom controller mode after configuration

### DIFF
--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -299,6 +299,17 @@ byte MCP_CAN::mcp2515_readStatus(void)
 }
 
 /*********************************************************************************************************
+** Function name:           mcp2515_setMode
+** Descriptions:            Sets and stores controller mode
+*********************************************************************************************************/
+byte MCP_CAN::mcp2515_setMode(const byte newmode)
+{
+    mcpMode = newmode;
+    return mcp2515_setCANCTRL_Mode(mcpMode);
+}
+
+
+/*********************************************************************************************************
 ** Function name:           mcp2515_setCANCTRL_Mode
 ** Descriptions:            set control mode
 *********************************************************************************************************/
@@ -640,7 +651,7 @@ byte MCP_CAN::mcp2515_init(const byte canSpeed, const byte clock)
                              MCP_RXB_RX_STDEXT);
 #endif
       // enter normal mode
-      res = mcp2515_setCANCTRL_Mode(MODE_NORMAL);
+      res = mcp2515_setMode(MODE_NORMAL);
       if (res)
       {
 #if DEBUG_EN
@@ -937,7 +948,7 @@ byte MCP_CAN::init_Mask(byte num, byte ext, unsigned long ulData)
     }
     else res =  MCP2515_FAIL;
 
-    res = mcp2515_setCANCTRL_Mode(MODE_NORMAL);
+    res = mcp2515_setCANCTRL_Mode(mcpMode);
     if (res > 0) {
 #if DEBUG_EN
         Serial.print("Enter normal mode fall\r\n");
@@ -1007,7 +1018,7 @@ byte MCP_CAN::init_Filt(byte num, byte ext, unsigned long ulData)
         res = MCP2515_FAIL;
     }
 
-    res = mcp2515_setCANCTRL_Mode(MODE_NORMAL);
+    res = mcp2515_setCANCTRL_Mode(mcpMode);
     if (res > 0)
     {
 #if DEBUG_EN

--- a/mcp_can.h
+++ b/mcp_can.h
@@ -62,6 +62,7 @@ class MCP_CAN
     byte   SPICS;
     SPIClass *pSPI;
     byte   nReservedTx;                     // Count of tx buffers for reserved send
+    byte   mcpMode;                         // Current controller mode
 
 /*
 *  mcp2515 driver function
@@ -90,6 +91,7 @@ private:
                                 const byte data);
 
     byte mcp2515_readStatus(void);                              // read mcp2515's Status
+    byte mcp2515_setMode(const byte newmode);                   // Sets and stores controller mode
     byte mcp2515_setCANCTRL_Mode(const byte newmode);           // set mode
     byte mcp2515_configRate(const byte canSpeed, const byte clock);  // set baudrate
     byte mcp2515_init(const byte canSpeed, const byte clock);   // mcp2515init


### PR DESCRIPTION
Add a new function storing the selected controller mode. This allows functions switching to various configuration modes to return to the user set mode. Useful if LOOPBACK is used during debugging.