### PR TITLE
Add GPIO-Support

### DIFF
--- a/examples/gpioRead/gpioRead.ino
+++ b/examples/gpioRead/gpioRead.ino
@@ -1,0 +1,41 @@
+// demo: Use TX2RTS as digital input
+// adlerweb, 2017-06-24
+#include <SPI.h>
+#include "mcp_can.h"
+
+#define SPI_CS_PIN 10
+
+MCP_CAN CAN(SPI_CS_PIN); // Set CS pin
+
+
+void setup()
+{
+    Serial.begin(115200);
+
+    while (CAN_OK != CAN.begin(CAN_500KBPS))              // init can bus : baudrate = 500k
+    {
+        Serial.println("CAN init failed, retry");
+        delay(100);
+    }
+    Serial.println("CAN init ok");
+
+    if(CAN.pinMode(MCP_TX2RTS, MCP_PIN_IN))
+    {
+        Serial.println("TX2RTS is now an input");
+    }
+    else
+    {
+        Serial.println("Could not switch TX2RTS");
+    }
+}
+
+void loop()
+{
+    Serial.print("TX2RTS is currently ");
+    Serial.println(CAN.digitalRead(MCP_TX2RTS));
+    delay(500);
+}
+
+/*********************************************************************************************************
+  END FILE
+*********************************************************************************************************/

--- a/examples/gpioWrite/gpioWrite.ino
+++ b/examples/gpioWrite/gpioWrite.ino
@@ -1,0 +1,55 @@
+// demo: Use RX0BF and RX1BF as digital outputs
+// adlerweb, 2017-06-24
+#include <SPI.h>
+#include "mcp_can.h"
+
+#define SPI_CS_PIN 10
+
+MCP_CAN CAN(SPI_CS_PIN); // Set CS pin
+
+
+void setup()
+{
+    Serial.begin(115200);
+
+    while (CAN_OK != CAN.begin(CAN_500KBPS))              // init can bus : baudrate = 500k
+    {
+        Serial.println("CAN init failed, retry");
+        delay(100);
+    }
+    Serial.println("CAN init ok");
+
+    if(CAN.pinMode(MCP_RX0BF, MCP_PIN_OUT))
+    {
+        Serial.println("RX0BF is now an output");
+    }
+    else
+    {
+        Serial.println("Could not switch RX0BF");
+    }
+
+    if(CAN.pinMode(MCP_RX1BF, MCP_PIN_OUT))
+    {
+        Serial.println("RX1BF is now an output");
+    }
+    else
+    {
+        Serial.println("Could not switch RX1BF");
+    }
+}
+
+void loop()
+{
+    Serial.println("10");
+    CAN.digitalWrite(MCP_RX0BF, HIGH);
+    CAN.digitalWrite(MCP_RX1BF, LOW);
+    delay(500);
+    Serial.println("01");
+    CAN.digitalWrite(MCP_RX0BF, LOW);
+    CAN.digitalWrite(MCP_RX1BF, HIGH);
+    delay(500);
+}
+
+/*********************************************************************************************************
+  END FILE
+*********************************************************************************************************/

--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -299,6 +299,17 @@ byte MCP_CAN::mcp2515_readStatus(void)
 }
 
 /*********************************************************************************************************
+** Function name:           mcp2515_setMode
+** Descriptions:            Sets and stores controller mode
+*********************************************************************************************************/
+byte MCP_CAN::mcp2515_setMode(const byte newmode)
+{
+    mcpMode = newmode;
+    return mcp2515_setCANCTRL_Mode(mcpMode);
+}
+
+
+/*********************************************************************************************************
 ** Function name:           mcp2515_setCANCTRL_Mode
 ** Descriptions:            set control mode
 *********************************************************************************************************/
@@ -640,7 +651,7 @@ byte MCP_CAN::mcp2515_init(const byte canSpeed, const byte clock)
                              MCP_RXB_RX_STDEXT);
 #endif
       // enter normal mode
-      res = mcp2515_setCANCTRL_Mode(MODE_NORMAL);
+      res = mcp2515_setMode(MODE_NORMAL);
       if (res)
       {
 #if DEBUG_EN
@@ -937,7 +948,7 @@ byte MCP_CAN::init_Mask(byte num, byte ext, unsigned long ulData)
     }
     else res =  MCP2515_FAIL;
 
-    res = mcp2515_setCANCTRL_Mode(MODE_NORMAL);
+    res = mcp2515_setCANCTRL_Mode(mcpMode);
     if (res > 0) {
 #if DEBUG_EN
         Serial.print("Enter normal mode fall\r\n");
@@ -1007,7 +1018,7 @@ byte MCP_CAN::init_Filt(byte num, byte ext, unsigned long ulData)
         res = MCP2515_FAIL;
     }
 
-    res = mcp2515_setCANCTRL_Mode(MODE_NORMAL);
+    res = mcp2515_setCANCTRL_Mode(mcpMode);
     if (res > 0)
     {
 #if DEBUG_EN

--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -1309,5 +1309,272 @@ byte MCP_CAN::isExtendedFrame(void)
 }
 
 /*********************************************************************************************************
+** Function name:           pinMode
+** Descriptions:            switch supported pins between HiZ, interrupt, output or input
+*********************************************************************************************************/
+bool MCP_CAN::pinMode(const byte pin, const byte mode)
+{
+    byte res;
+    bool ret=true;
+
+    switch(pin)
+    {
+        case MCP_RX0BF:
+            switch(mode) {
+                case MCP_PIN_HIZ:
+                    mcp2515_modifyRegister(MCP_BFPCTRL, B0BFE, 0);
+                break;
+                case MCP_PIN_INT:
+                    mcp2515_modifyRegister(MCP_BFPCTRL, B0BFM | B0BFE, B0BFM | B0BFE);
+                break;
+                case MCP_PIN_OUT:
+                    mcp2515_modifyRegister(MCP_BFPCTRL, B0BFM | B0BFE, B0BFE);
+                break;
+                default:
+#if DEBUG_EN
+                    Serial.print("Invalid mode request\r\n");
+#endif
+                    return false;
+            }
+            return true;
+        break;
+        case MCP_RX1BF:
+            switch(mode) {
+                case MCP_PIN_HIZ:
+                    mcp2515_modifyRegister(MCP_BFPCTRL, B1BFE, 0);
+                break;
+                case MCP_PIN_INT:
+                    mcp2515_modifyRegister(MCP_BFPCTRL, B1BFM | B1BFE, B1BFM | B1BFE);
+                break;
+                case MCP_PIN_OUT:
+                    mcp2515_modifyRegister(MCP_BFPCTRL, B1BFM | B1BFE, B1BFE);
+                break;
+                default:
+#if DEBUG_EN
+                    Serial.print("Invalid mode request\r\n");
+#endif
+                    return false;
+            }
+            return true;
+        break;
+        case MCP_TX0RTS:
+            res = mcp2515_setCANCTRL_Mode(MODE_CONFIG);
+            if(res > 0)
+            {
+#if DEBUG_EN
+                Serial.print("Entering Configuration Mode Failure...\r\n");
+#else
+                delay(10);
+#endif
+                return false;
+            }
+            switch(mode) {
+                case MCP_PIN_INT:
+                    mcp2515_modifyRegister(MCP_TXRTSCTRL, B0RTSM, B0RTSM);
+                break;
+                case MCP_PIN_IN:
+                    mcp2515_modifyRegister(MCP_TXRTSCTRL, B0RTSM, 0);
+                break;
+                default:
+#if DEBUG_EN
+                    Serial.print("Invalid mode request\r\n");
+#endif
+                    ret=false;
+            }
+            res = mcp2515_setCANCTRL_Mode(mcpMode);
+            if(res)
+            {
+#if DEBUG_EN
+                Serial.print("`Setting ID Mode Failure...\r\n");
+#else
+                delay(10);
+#endif
+                return false;
+            }
+            return ret;
+        break;
+        case MCP_TX1RTS:
+            res = mcp2515_setCANCTRL_Mode(MODE_CONFIG);
+            if(res > 0)
+            {
+#if DEBUG_EN
+                Serial.print("Entering Configuration Mode Failure...\r\n");
+#else
+                delay(10);
+#endif
+                return false;
+            }
+            switch(mode) {
+                case MCP_PIN_INT:
+                    mcp2515_modifyRegister(MCP_TXRTSCTRL, B1RTSM, B1RTSM);
+                break;
+                case MCP_PIN_IN:
+                    mcp2515_modifyRegister(MCP_TXRTSCTRL, B1RTSM, 0);
+                break;
+                default:
+#if DEBUG_EN
+                    Serial.print("Invalid mode request\r\n");
+#endif
+                    ret=false;
+            }
+            res = mcp2515_setCANCTRL_Mode(mcpMode);
+            if(res)
+            {
+#if DEBUG_EN
+                Serial.print("`Setting ID Mode Failure...\r\n");
+#else
+                delay(10);
+#endif
+                return false;
+            }
+            return ret;
+        break;
+        case MCP_TX2RTS:
+            res = mcp2515_setCANCTRL_Mode(MODE_CONFIG);
+            if(res > 0)
+            {
+#if DEBUG_EN
+                Serial.print("Entering Configuration Mode Failure...\r\n");
+#else
+                delay(10);
+#endif
+                return false;
+            }
+            switch(mode) {
+                case MCP_PIN_INT:
+                    mcp2515_modifyRegister(MCP_TXRTSCTRL, B2RTSM, B2RTSM);
+                break;
+                case MCP_PIN_IN:
+                    mcp2515_modifyRegister(MCP_TXRTSCTRL, B2RTSM, 0);
+                break;
+                default:
+#if DEBUG_EN
+                    Serial.print("Invalid mode request\r\n");
+#endif
+                    ret=false;
+            }
+            res = mcp2515_setCANCTRL_Mode(mcpMode);
+            if(res)
+            {
+#if DEBUG_EN
+                Serial.print("`Setting ID Mode Failure...\r\n");
+#else
+                delay(10);
+#endif
+                return false;
+            }
+            return ret;
+        break;
+        default:
+#if DEBUG_EN
+            Serial.print("Invalid pin for mode request\r\n");
+#endif
+            return false;
+    }
+}
+
+/*********************************************************************************************************
+** Function name:           digitalWrite
+** Descriptions:            write HIGH or LOW to RX0BF/RX1BF
+*********************************************************************************************************/
+bool MCP_CAN::digitalWrite(const byte pin, const byte mode) {
+    switch(pin)
+    {
+        case MCP_RX0BF:
+            switch(mode) {
+                case HIGH:
+                    mcp2515_modifyRegister(MCP_BFPCTRL, B0BFS, B0BFS);
+                    return true;
+                break;
+                default:
+                    mcp2515_modifyRegister(MCP_BFPCTRL, B0BFS, 0);
+                    return true;
+            }
+        break;
+        case MCP_RX1BF:
+            switch(mode) {
+                case HIGH:
+                    mcp2515_modifyRegister(MCP_BFPCTRL, B1BFS, B1BFS);
+                    return true;
+                break;
+                default:
+                    mcp2515_modifyRegister(MCP_BFPCTRL, B1BFS, 0);
+                    return true;
+            }
+        break;
+        default:
+#if DEBUG_EN
+            Serial.print("Invalid pin for digitalWrite\r\n");
+#endif
+            return false;
+    }
+}
+
+/*********************************************************************************************************
+** Function name:           digitalRead
+** Descriptions:            read HIGH or LOW from supported pins
+*********************************************************************************************************/
+byte MCP_CAN::digitalRead(const byte pin) {
+    switch(pin)
+    {
+        case MCP_RX0BF:
+            if((mcp2515_readRegister(MCP_BFPCTRL) & B0BFS) > 0)
+            {
+                return HIGH;
+            }
+            else
+            {
+                return LOW;
+            }
+        break;
+        case MCP_RX1BF:
+            if((mcp2515_readRegister(MCP_BFPCTRL) & B1BFS) > 0)
+            {
+                return HIGH;
+            }
+            else
+            {
+                return LOW;
+            }
+        break;
+        case MCP_TX0RTS:
+            if((mcp2515_readRegister(MCP_TXRTSCTRL) & B0RTS) > 0)
+            {
+                return HIGH;
+            }
+            else
+            {
+                return LOW;
+            }
+        break;
+        case MCP_TX1RTS:
+            if((mcp2515_readRegister(MCP_TXRTSCTRL) & B1RTS) > 0)
+            {
+                return HIGH;
+            }
+            else
+            {
+                return LOW;
+            }
+        break;
+        case MCP_TX2RTS:
+            if((mcp2515_readRegister(MCP_TXRTSCTRL) & B2RTS) > 0)
+            {
+                return HIGH;
+            }
+            else
+            {
+                return LOW;
+            }
+        break;
+        default:
+#if DEBUG_EN
+            Serial.print("Invalid pin for digitalRead\r\n");
+#endif
+            return LOW;
+    }
+}
+
+/*********************************************************************************************************
   END FILE
 *********************************************************************************************************/

--- a/mcp_can.h
+++ b/mcp_can.h
@@ -151,6 +151,9 @@ public:
     byte checkClearRxStatus(byte *status);                          // read and clear and return first found rx status bit
     byte checkClearTxStatus(byte *status, byte iTxBuf=0xff);        // read and clear and return first found or buffer specified tx status bit
 
+    bool pinMode(const byte pin, const byte mode);                  // switch supported pins between HiZ, interrupt, output or input
+    bool digitalWrite(const byte pin, const byte mode);             // write HIGH or LOW to RX0BF/RX1BF
+    byte digitalRead(const byte pin);                               // read HIGH or LOW from supported pins
 };
 
 #endif

--- a/mcp_can.h
+++ b/mcp_can.h
@@ -62,6 +62,7 @@ class MCP_CAN
     byte   SPICS;
     SPIClass *pSPI;
     byte   nReservedTx;                     // Count of tx buffers for reserved send
+    byte   mcpMode;                         // Current controller mode
 
 /*
 *  mcp2515 driver function
@@ -90,6 +91,7 @@ private:
                                 const byte data);
 
     byte mcp2515_readStatus(void);                              // read mcp2515's Status
+    byte mcp2515_setMode(const byte newmode);                   // Sets and stores controller mode
     byte mcp2515_setCANCTRL_Mode(const byte newmode);           // set mode
     byte mcp2515_configRate(const byte canSpeed, const byte clock);  // set baudrate
     byte mcp2515_init(const byte canSpeed, const byte clock);   // mcp2515init

--- a/mcp_can_dfs.h
+++ b/mcp_can_dfs.h
@@ -126,6 +126,8 @@
 #define MCP_RXF2SIDL    0x09
 #define MCP_RXF2EID8    0x0A
 #define MCP_RXF2EID0    0x0B
+#define MCP_BFPCTRL     0x0C
+#define MCP_TXRTSCTRL   0x0D
 #define MCP_CANSTAT     0x0E
 #define MCP_CANCTRL     0x0F
 #define MCP_RXF3SIDH    0x10
@@ -248,6 +250,24 @@
 #define MCP_ERRIF       0x20
 #define MCP_WAKIF       0x40
 #define MCP_MERRF       0x80
+
+// BFPCTRL Register Bits
+
+#define B1BFS           0x20
+#define B0BFS           0x10
+#define B1BFE           0x08
+#define B0BFE           0x04
+#define B1BFM           0x02
+#define B0BFM           0x01
+
+// TXRTCTRL Register Bits
+
+#define B2RTS           0x20
+#define B1RTS           0x10
+#define B0RTS           0x08
+#define B2RTSM          0x04
+#define B1RTSM          0x02
+#define B0RTSM          0x01
 
 // clock
 
@@ -390,8 +410,8 @@
 #define MCP_RXBUF_0 (MCP_RXB0SIDH)
 #define MCP_RXBUF_1 (MCP_RXB1SIDH)
 
-#define MCP2515_SELECT()   digitalWrite(SPICS, LOW)
-#define MCP2515_UNSELECT() digitalWrite(SPICS, HIGH)
+#define MCP2515_SELECT()   ::digitalWrite(SPICS, LOW)
+#define MCP2515_UNSELECT() ::digitalWrite(SPICS, HIGH)
 
 #define MCP2515_OK         (0)
 #define MCP2515_FAIL       (1)
@@ -403,6 +423,16 @@
 
 #define CANSENDTIMEOUT (200)                                            // milliseconds
 
+#define MCP_PIN_HIZ (0)
+#define MCP_PIN_INT (1)
+#define MCP_PIN_OUT (2)
+#define MCP_PIN_IN  (3)
+
+#define MCP_RX0BF (0)
+#define MCP_RX1BF (1)
+#define MCP_TX0RTS (2)
+#define MCP_TX1RTS (3)
+#define MCP_TX2RTS (4)
 
 // initial value of gCANAutoProcess
 


### PR DESCRIPTION
Some of the status pins can be controlled using configuration registers. This additions allow to use them as regular GPIO using pinMode/digitalRead/digitalWrite.

Based on #55 - could also be used with the previous hardcoded style by cherry-picking 0450568699ee11895f963d1ca248652698d1c6ed and changing `mcp2515_setCANCTRL_Mode(mcpMode);` to `mcp2515_setCANCTRL_Mode(MODE_NORMAL);`