### PR TITLE
Add MCP2515 8MHz 83.3kbps bitrate support

### DIFF
--- a/src/mcp2515_can.cpp
+++ b/src/mcp2515_can.cpp
@@ -680,6 +680,12 @@ byte mcp2515_can::mcp2515_configRate(const byte canSpeed, const byte clock) {
                     cfg3 = MCP_8MHz_80kBPS_CFG3;
                     break;
 
+                case (CAN_83K3BPS) :
+                    cfg1 = MCP_8MHz_83k3BPS_CFG1;
+                    cfg2 = MCP_8MHz_83k3BPS_CFG2;
+                    cfg3 = MCP_8MHz_83k3BPS_CFG3;
+                    break;
+
 				case (CAN_95K2BPS):
                     cfg1 = MCP_8MHz_95k2BPS_CFG1;
                     cfg2 = MCP_8MHz_95k2BPS_CFG2;

--- a/src/mcp2515_can_dfs.h
+++ b/src/mcp2515_can_dfs.h
@@ -456,6 +456,10 @@
 #define MCP_8MHz_80kBPS_CFG2 (0xbf)
 #define MCP_8MHz_80kBPS_CFG3 (0x07)
 
+#define MCP_8MHz_83k3BPS_CFG1 (0x01)
+#define MCP_8MHz_83k3BPS_CFG2 (0xBE)
+#define MCP_8MHz_83k3BPS_CFG3 (0x07)
+
 #define MCP_8MHz_50kBPS_CFG1 (0x03)
 #define MCP_8MHz_50kBPS_CFG2 (0xb4)
 #define MCP_8MHz_50kBPS_CFG3 (0x06)


### PR DESCRIPTION
## Summary
- add the missing MCP2515 8MHz 83.3kbps timing macros
- wire CAN_83K3BPS into the MCP_8MHz bitrate switch

This addresses the missing support discussed in #79.