### PR TITLE
fix: use pSPI->begin() and add skipSpiBegin option for ESP32

### DIFF
--- a/src/mcp2515_can.cpp
+++ b/src/mcp2515_can.cpp
@@ -1058,8 +1058,8 @@ byte mcp2515_can::mcp2515_getNextFreeTXBuf(byte* txbuf_n) {               // get
 ** Function name:           begin
 ** Descriptions:            init can and set speed
 *********************************************************************************************************/
-byte mcp2515_can::begin(uint32_t speedset, const byte clockset) {
-    pSPI->begin();
+byte mcp2515_can::begin(uint32_t speedset, const byte clockset, const bool _initSPI) {
+    if (_initSPI) pSPI->begin();
     byte res = mcp2515_init((byte)speedset, clockset);
 
     return ((res == MCP2515_OK) ? CAN_OK : CAN_FAILINIT);

--- a/src/mcp2515_can.h
+++ b/src/mcp2515_can.h
@@ -69,7 +69,7 @@ public:
     {
         return MCP_N_TXBUFFERS - 1; // read index of last tx buffer
     }
-    virtual byte begin(uint32_t speedset, const byte clockset = MCP_16MHz);                                                                                 // init can
+    virtual byte begin(uint32_t speedset, const byte clockset = MCP_16MHz, const bool _initSPI = true); // init can
     virtual byte init_Mask(byte num, byte ext, unsigned long ulData);                                                                                   // init Masks
     virtual byte init_Filt(byte num, byte ext, unsigned long ulData);                                                                                   // init filters
     virtual void setSleepWakeup(byte enable);                                                                                                           // Enable or disable the wake up interrupt (If disabled the MCP2515 will not be woken up by CAN bus activity, making it send only)

--- a/src/mcp2518fd_can.cpp
+++ b/src/mcp2518fd_can.cpp
@@ -55,8 +55,8 @@ uint16_t DRV_CANFDSPI_CalculateCRC16(uint8_t *data, uint16_t size) {
 ** Function name:           begin
 ** Descriptions:            init can and set speed
 *********************************************************************************************************/
-byte mcp2518fd::begin(uint32_t speedset, const byte clockset) {
-  SPI.begin();
+byte mcp2518fd::begin(uint32_t speedset, const byte clockset, const bool _initSPI) {
+  if (_initSPI) pSPI->begin();
 
   /* compatible layer translation */
   speedset = bittime_compat_to_mcp2518fd(speedset);

--- a/src/mcp2518fd_can.h
+++ b/src/mcp2518fd_can.h
@@ -112,7 +112,8 @@ public:
    *          or fill by CANFD::BITRATE()
    */
   virtual byte begin(uint32_t speedset,
-                     const byte clockset = MCP2518FD_40MHz); // init can
+                     const byte clockset = MCP2518FD_40MHz,
+                     const bool _initSPI = true); // init can
   virtual byte init_Mask(byte num, byte ext, unsigned long ulData);
   virtual byte init_Filt(byte num, byte ext,
                          unsigned long ulData); // init filters

--- a/src/mcp_can.h
+++ b/src/mcp_can.h
@@ -76,7 +76,7 @@ public:
      * speedset be in MCP_BITTIME_SETUP
      * clockset be in MCP_CLOCK_T
      */
-    virtual byte begin(uint32_t speedset, const byte clockset) = 0;                     // init can
+    virtual byte begin(uint32_t speedset, const byte clockset, const bool _initSPI = true) = 0; // init can
     virtual byte init_Mask(byte num, byte ext, unsigned long ulData) = 0;               // init Masks
     virtual byte init_Filt(byte num, byte ext, unsigned long ulData) = 0;               // init filters
     virtual void setSleepWakeup(byte enable) = 0;                                       // Enable or disable the wake up interrupt


### PR DESCRIPTION
## Summary

- Replace hardcoded `SPI.begin()` with `pSPI->begin()` in mcp2518fd (consistent with MCP2515)
- Add optional `_initSPI` parameter (default `true`) to `begin()` across MCP_CAN, mcp2515, and mcp2518fd
- ESP32 users can call `CAN.begin(CAN_500KBPS, MCP_8MHZ, false)` to skip SPI re-initialization

## Why

ESP32's GPIO matrix requires users to call `SPI.begin(SCK, MISO, MOSI, CS)` with custom pins before using the library. The hardcoded `SPI.begin()` in `mcp2518fd::begin()` overwrites this configuration, breaking ESP32 support.

## Backward compatibility

- Default `_initSPI = true` — existing code works unchanged
- Arduino Uno and other AVR platforms are unaffected (`pSPI` already points to `&SPI`)

Closes #158